### PR TITLE
Implement remaining Remote Offline Store methods

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1121,6 +1121,11 @@ class FeatureStore:
         dataset.min_event_timestamp = from_.metadata.min_event_timestamp
         dataset.max_event_timestamp = from_.metadata.max_event_timestamp
 
+        # Added to handle the case that the offline store is remote
+        self._registry.apply_data_source(
+            storage.to_data_source(), self.project, commit=True
+        )
+
         from_.persist(storage=storage, allow_overwrite=allow_overwrite)
 
         dataset = dataset.with_retrieval_job(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1121,11 +1121,6 @@ class FeatureStore:
         dataset.min_event_timestamp = from_.metadata.min_event_timestamp
         dataset.max_event_timestamp = from_.metadata.max_event_timestamp
 
-        # Added to handle the case that the offline store is remote
-        self._registry.apply_data_source(
-            storage.to_data_source(), self.project, commit=True
-        )
-
         from_.persist(storage=storage, allow_overwrite=allow_overwrite)
 
         dataset = dataset.with_retrieval_job(

--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -1,5 +1,3 @@
-import json
-import logging
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -7,9 +5,8 @@ from typing import Any, Callable, List, Literal, Optional, Union
 
 import pandas as pd
 import pyarrow as pa
-import pyarrow.flight as fl
 import pyarrow.parquet
-from pydantic import StrictInt, StrictStr
+from pydantic import StrictStr
 
 from feast import OnDemandFeatureView
 from feast.data_source import DataSource
@@ -20,53 +17,62 @@ from feast.infra.offline_stores.offline_store import (
     RetrievalJob,
 )
 from feast.infra.registry.base_registry import BaseRegistry
+from feast.infra.registry.registry import Registry
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
-
-logger = logging.getLogger(__name__)
+from feast.usage import log_exceptions_and_usage
 
 
 class RemoteOfflineStoreConfig(FeastConfigBaseModel):
-    type: Literal["remote"] = "remote"
-    host: StrictStr
-    """ str: remote offline store server port, e.g. the host URL for offline store  of arrow flight server. """
 
-    port: Optional[StrictInt] = None
-    """ str: remote offline store server port."""
+    offline_type: StrictStr = "remote"
+    """ str: Provider name or a class name that implements Offline store."""
+
+    path: StrictStr = ""
+    """ str: Path to metadata store.
+    If offline_type is 'remote', then this is a URL for offline server """
+
+    host: StrictStr = ""
+    """ str: host to offline store.
+    If offline_type is 'remote', then this is a host URL for offline store  of arrow flight server """
+
+    port: StrictStr = ""
+    """ str: host to offline store."""
 
 
 class RemoteRetrievalJob(RetrievalJob):
     def __init__(
-        self,
-        client: fl.FlightClient,
-        feature_view_names: List[str],
-        feature_refs: List[str],
-        entity_df: Union[pd.DataFrame, str],
-        project: str,
-        full_feature_names: bool = False,
+            self,
+            config: RepoConfig,
+            feature_refs: List[str],
+            entity_df: Union[pd.DataFrame, str],
+            # TODO add missing parameters from the OfflineStore API
     ):
+        # Generate unique command identifier
+        self.command = str(uuid.uuid4())
         # Initialize the client connection
-        self.client = client
-        self.feature_view_names = feature_view_names
-        self.feature_refs = feature_refs
-        self.entity_df = entity_df
-        self.project = project
-        self._full_feature_names = full_feature_names
+        self.client = pa.flight.connect(f"grpc://{config.offline_store.host}:{config.offline_store.port}")
+        # Put API parameters
+        self._put_parameters(feature_refs, entity_df)
 
-    @property
-    def full_feature_names(self) -> bool:
-        return self._full_feature_names
-
-    # TODO add one specialized implementation for each OfflineStore API
-    # This can result in a dictionary of functions indexed by api (e.g., "get_historical_features")
-    def _put_parameters(self, command_descriptor):
-        entity_df_table = pa.Table.from_pandas(self.entity_df)
-
-        writer, _ = self.client.do_put(
-            command_descriptor,
-            entity_df_table.schema,
-        )
-
+    def _put_parameters(self, feature_refs, entity_df):
+        entity_df_table = pa.Table.from_pandas(entity_df)
+        historical_flight_descriptor = pa.flight.FlightDescriptor.for_command(self.command)
+        writer, _ = self.client.do_put(historical_flight_descriptor,
+                                       entity_df_table.schema.with_metadata({
+                                           'command': self.command,
+                                           'api': 'get_historical_features',
+                                           'param': 'entity_df'}))
         writer.write_table(entity_df_table)
+        writer.close()
+
+        features_array = pa.array(feature_refs)
+        features_batch = pa.RecordBatch.from_arrays([features_array], ['features'])
+        writer, _ = self.client.do_put(historical_flight_descriptor,
+                                       features_batch.schema.with_metadata({
+                                           'command': self.command,
+                                           'api': 'get_historical_features',
+                                           'param': 'features'}))
+        writer.write_batch(features_batch)
         writer.close()
 
     # Invoked to realize the Pandas DataFrame
@@ -77,24 +83,8 @@ class RemoteRetrievalJob(RetrievalJob):
     # Invoked to synchronously execute the underlying query and return the result as an arrow table
     # This is where do_get service is invoked
     def _to_arrow_internal(self, timeout: Optional[int] = None) -> pa.Table:
-        # Generate unique command identifier
-        command_id = str(uuid.uuid4())
-        command = {
-            "command_id": command_id,
-            "api": "get_historical_features",
-            "feature_view_names": self.feature_view_names,
-            "feature_refs": self.feature_refs,
-            "project": self.project,
-            "full_feature_names": self._full_feature_names,
-        }
-        command_descriptor = fl.FlightDescriptor.for_command(
-            json.dumps(
-                command,
-            )
-        )
-
-        self._put_parameters(command_descriptor)
-        flight = self.client.get_flight_info(command_descriptor)
+        upload_descriptor = pa.flight.FlightDescriptor.for_command(self.command)
+        flight = self.client.get_flight_info(upload_descriptor)
         ticket = flight.endpoints[0].ticket
 
         reader = self.client.do_get(ticket)
@@ -106,79 +96,65 @@ class RemoteRetrievalJob(RetrievalJob):
 
 
 class RemoteOfflineStore(OfflineStore):
-    @staticmethod
+    def __init__(
+            self,
+
+            arrow_host,
+            arrow_port
+    ):
+        self.arrow_host = arrow_host
+        self.arrow_port = arrow_port
+
+    @log_exceptions_and_usage(offline_store="remote")
     def get_historical_features(
-        config: RepoConfig,
-        feature_views: List[FeatureView],
-        feature_refs: List[str],
-        entity_df: Union[pd.DataFrame, str],
-        registry: BaseRegistry,
-        project: str,
-        full_feature_names: bool = False,
+            self,
+            config: RepoConfig,
+            feature_views: List[FeatureView],
+            feature_refs: List[str],
+            entity_df: Union[pd.DataFrame, str],
+            registry: Registry = None,
+            project: str = '',
+            full_feature_names: bool = False,
     ) -> RemoteRetrievalJob:
-        assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
+        offline_store_config = config.offline_store
+        assert isinstance(config.offline_store_config, RemoteOfflineStoreConfig)
+        store_type = offline_store_config.type
+        port = offline_store_config.port
+        host = offline_store_config.host
 
-        # TODO: extend RemoteRetrievalJob API with all method parameters
+        return RemoteRetrievalJob(RepoConfig, feature_refs, entity_df)
 
-        # Initialize the client connection
-        location = f"grpc://{config.offline_store.host}:{config.offline_store.port}"
-        client = fl.connect(location=location)
-        logger.info(f"Connecting FlightClient at {location}")
+    @log_exceptions_and_usage(offline_store="remote")
+    def pull_latest_from_table_or_query(self,
+                                        config: RepoConfig,
+                                        data_source: DataSource,
+                                        join_key_columns: List[str],
+                                        feature_name_columns: List[str],
+                                        timestamp_field: str,
+                                        created_timestamp_column: Optional[str],
+                                        start_date: datetime,
+                                        end_date: datetime) -> RetrievalJob:
+        """ Pulls data from the offline store for use in materialization."""
+        print("Pulling latest features from my offline store")
+        # Implementation here.
+        pass
 
-        feature_view_names = [fv.name for fv in feature_views]
-        return RemoteRetrievalJob(
-            client=client,
-            feature_view_names=feature_view_names,
-            feature_refs=feature_refs,
-            entity_df=entity_df,
-            project=project,
-            full_feature_names=full_feature_names,
-        )
-
-    @staticmethod
-    def pull_all_from_table_or_query(
-        config: RepoConfig,
-        data_source: DataSource,
-        join_key_columns: List[str],
-        feature_name_columns: List[str],
-        timestamp_field: str,
-        start_date: datetime,
-        end_date: datetime,
-    ) -> RetrievalJob:
-        # TODO Implementation here.
-        raise NotImplementedError
-
-    @staticmethod
-    def pull_latest_from_table_or_query(
-        config: RepoConfig,
-        data_source: DataSource,
-        join_key_columns: List[str],
-        feature_name_columns: List[str],
-        timestamp_field: str,
-        created_timestamp_column: Optional[str],
-        start_date: datetime,
-        end_date: datetime,
-    ) -> RetrievalJob:
-        # TODO Implementation here.
-        raise NotImplementedError
-
-    @staticmethod
     def write_logged_features(
-        config: RepoConfig,
-        data: Union[pyarrow.Table, Path],
-        source: LoggingSource,
-        logging_config: LoggingConfig,
-        registry: BaseRegistry,
+            config: RepoConfig,
+            data: Union[pyarrow.Table, Path],
+            source: LoggingSource,
+            logging_config: LoggingConfig,
+            registry: BaseRegistry,
     ):
-        # TODO Implementation here.
-        raise NotImplementedError
+        """ Optional method to have Feast support logging your online features."""
+        # Implementation here.
+        pass
 
-    @staticmethod
     def offline_write_batch(
-        config: RepoConfig,
-        feature_view: FeatureView,
-        table: pyarrow.Table,
-        progress: Optional[Callable[[int], Any]],
+            config: RepoConfig,
+            feature_view: FeatureView,
+            table: pyarrow.Table,
+            progress: Optional[Callable[[int], Any]],
     ):
-        # TODO Implementation here.
-        raise NotImplementedError
+        # Implementation here.
+        pass

--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -1,5 +1,3 @@
-import json
-import logging
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -7,9 +5,8 @@ from typing import Any, Callable, List, Literal, Optional, Union
 
 import pandas as pd
 import pyarrow as pa
-import pyarrow.flight as fl
 import pyarrow.parquet
-from pydantic import StrictInt, StrictStr
+from pydantic import StrictStr
 
 from feast import OnDemandFeatureView
 from feast.data_source import DataSource
@@ -20,55 +17,62 @@ from feast.infra.offline_stores.offline_store import (
     RetrievalJob,
 )
 from feast.infra.registry.base_registry import BaseRegistry
+from feast.infra.registry.registry import Registry
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
-
-logger = logging.getLogger(__name__)
+from feast.usage import log_exceptions_and_usage
 
 
 class RemoteOfflineStoreConfig(FeastConfigBaseModel):
-    type: Literal["remote"] = "remote"
-    host: StrictStr
-    """ str: remote offline store server port, e.g. the host URL for offline store  of arrow flight server. """
 
-    port: Optional[StrictInt] = None
-    """ str: remote offline store server port."""
+    offline_type: StrictStr = "remote"
+    """ str: Provider name or a class name that implements Offline store."""
+
+    path: StrictStr = ""
+    """ str: Path to metadata store.
+    If offline_type is 'remote', then this is a URL for offline server """
+
+    host: StrictStr = ""
+    """ str: host to offline store.
+    If offline_type is 'remote', then this is a host URL for offline store  of arrow flight server """
+
+    port: StrictStr = ""
+    """ str: host to offline store."""
 
 
 class RemoteRetrievalJob(RetrievalJob):
     def __init__(
-        self,
-        client: fl.FlightClient,
-        feature_view_names: List[str],
-        name_aliases: List[Optional[str]],
-        feature_refs: List[str],
-        entity_df: Union[pd.DataFrame, str],
-        project: str,
-        full_feature_names: bool = False,
+            self,
+            config: RepoConfig,
+            feature_refs: List[str],
+            entity_df: Union[pd.DataFrame, str],
+            # TODO add missing parameters from the OfflineStore API
     ):
+        # Generate unique command identifier
+        self.command = str(uuid.uuid4())
         # Initialize the client connection
-        self.client = client
-        self.feature_view_names = feature_view_names
-        self.name_aliases = name_aliases
-        self.feature_refs = feature_refs
-        self.entity_df = entity_df
-        self.project = project
-        self._full_feature_names = full_feature_names
+        self.client = pa.flight.connect(f"grpc://{config.offline_store.host}:{config.offline_store.port}")
+        # Put API parameters
+        self._put_parameters(feature_refs, entity_df)
 
-    @property
-    def full_feature_names(self) -> bool:
-        return self._full_feature_names
-
-    # TODO add one specialized implementation for each OfflineStore API
-    # This can result in a dictionary of functions indexed by api (e.g., "get_historical_features")
-    def _put_parameters(self, command_descriptor):
-        entity_df_table = pa.Table.from_pandas(self.entity_df)
-
-        writer, _ = self.client.do_put(
-            command_descriptor,
-            entity_df_table.schema,
-        )
-
+    def _put_parameters(self, feature_refs, entity_df):
+        entity_df_table = pa.Table.from_pandas(entity_df)
+        historical_flight_descriptor = pa.flight.FlightDescriptor.for_command(self.command)
+        writer, _ = self.client.do_put(historical_flight_descriptor,
+                                       entity_df_table.schema.with_metadata({
+                                           'command': self.command,
+                                           'api': 'get_historical_features',
+                                           'param': 'entity_df'}))
         writer.write_table(entity_df_table)
+        writer.close()
+
+        features_array = pa.array(feature_refs)
+        features_batch = pa.RecordBatch.from_arrays([features_array], ['features'])
+        writer, _ = self.client.do_put(historical_flight_descriptor,
+                                       features_batch.schema.with_metadata({
+                                           'command': self.command,
+                                           'api': 'get_historical_features',
+                                           'param': 'features'}))
+        writer.write_batch(features_batch)
         writer.close()
 
     # Invoked to realize the Pandas DataFrame
@@ -79,25 +83,8 @@ class RemoteRetrievalJob(RetrievalJob):
     # Invoked to synchronously execute the underlying query and return the result as an arrow table
     # This is where do_get service is invoked
     def _to_arrow_internal(self, timeout: Optional[int] = None) -> pa.Table:
-        # Generate unique command identifier
-        command_id = str(uuid.uuid4())
-        command = {
-            "command_id": command_id,
-            "api": "get_historical_features",
-            "feature_view_names": self.feature_view_names,
-            "name_aliases": self.name_aliases,
-            "feature_refs": self.feature_refs,
-            "project": self.project,
-            "full_feature_names": self._full_feature_names,
-        }
-        command_descriptor = fl.FlightDescriptor.for_command(
-            json.dumps(
-                command,
-            )
-        )
-
-        self._put_parameters(command_descriptor)
-        flight = self.client.get_flight_info(command_descriptor)
+        upload_descriptor = pa.flight.FlightDescriptor.for_command(self.command)
+        flight = self.client.get_flight_info(upload_descriptor)
         ticket = flight.endpoints[0].ticket
 
         reader = self.client.do_get(ticket)
@@ -109,81 +96,65 @@ class RemoteRetrievalJob(RetrievalJob):
 
 
 class RemoteOfflineStore(OfflineStore):
-    @staticmethod
+    def __init__(
+            self,
+
+            arrow_host,
+            arrow_port
+    ):
+        self.arrow_host = arrow_host
+        self.arrow_port = arrow_port
+
+    @log_exceptions_and_usage(offline_store="remote")
     def get_historical_features(
-        config: RepoConfig,
-        feature_views: List[FeatureView],
-        feature_refs: List[str],
-        entity_df: Union[pd.DataFrame, str],
-        registry: BaseRegistry,
-        project: str,
-        full_feature_names: bool = False,
+            self,
+            config: RepoConfig,
+            feature_views: List[FeatureView],
+            feature_refs: List[str],
+            entity_df: Union[pd.DataFrame, str],
+            registry: Registry = None,
+            project: str = '',
+            full_feature_names: bool = False,
     ) -> RemoteRetrievalJob:
-        assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
+        offline_store_config = config.offline_store
+        assert isinstance(config.offline_store_config, RemoteOfflineStoreConfig)
+        store_type = offline_store_config.type
+        port = offline_store_config.port
+        host = offline_store_config.host
 
-        # TODO: extend RemoteRetrievalJob API with all method parameters
+        return RemoteRetrievalJob(RepoConfig, feature_refs, entity_df)
 
-        # Initialize the client connection
-        location = f"grpc://{config.offline_store.host}:{config.offline_store.port}"
-        client = fl.connect(location=location)
-        logger.info(f"Connecting FlightClient at {location}")
+    @log_exceptions_and_usage(offline_store="remote")
+    def pull_latest_from_table_or_query(self,
+                                        config: RepoConfig,
+                                        data_source: DataSource,
+                                        join_key_columns: List[str],
+                                        feature_name_columns: List[str],
+                                        timestamp_field: str,
+                                        created_timestamp_column: Optional[str],
+                                        start_date: datetime,
+                                        end_date: datetime) -> RetrievalJob:
+        """ Pulls data from the offline store for use in materialization."""
+        print("Pulling latest features from my offline store")
+        # Implementation here.
+        pass
 
-        feature_view_names = [fv.name for fv in feature_views]
-        name_aliases = [fv.projection.name_alias for fv in feature_views]
-        return RemoteRetrievalJob(
-            client=client,
-            feature_view_names=feature_view_names,
-            name_aliases=name_aliases,
-            feature_refs=feature_refs,
-            entity_df=entity_df,
-            project=project,
-            full_feature_names=full_feature_names,
-        )
-
-    @staticmethod
-    def pull_all_from_table_or_query(
-        config: RepoConfig,
-        data_source: DataSource,
-        join_key_columns: List[str],
-        feature_name_columns: List[str],
-        timestamp_field: str,
-        start_date: datetime,
-        end_date: datetime,
-    ) -> RetrievalJob:
-        # TODO Implementation here.
-        raise NotImplementedError
-
-    @staticmethod
-    def pull_latest_from_table_or_query(
-        config: RepoConfig,
-        data_source: DataSource,
-        join_key_columns: List[str],
-        feature_name_columns: List[str],
-        timestamp_field: str,
-        created_timestamp_column: Optional[str],
-        start_date: datetime,
-        end_date: datetime,
-    ) -> RetrievalJob:
-        # TODO Implementation here.
-        raise NotImplementedError
-
-    @staticmethod
     def write_logged_features(
-        config: RepoConfig,
-        data: Union[pyarrow.Table, Path],
-        source: LoggingSource,
-        logging_config: LoggingConfig,
-        registry: BaseRegistry,
+            config: RepoConfig,
+            data: Union[pyarrow.Table, Path],
+            source: LoggingSource,
+            logging_config: LoggingConfig,
+            registry: BaseRegistry,
     ):
-        # TODO Implementation here.
-        raise NotImplementedError
+        """ Optional method to have Feast support logging your online features."""
+        # Implementation here.
+        pass
 
-    @staticmethod
     def offline_write_batch(
-        config: RepoConfig,
-        feature_view: FeatureView,
-        table: pyarrow.Table,
-        progress: Optional[Callable[[int], Any]],
+            config: RepoConfig,
+            feature_view: FeatureView,
+            table: pyarrow.Table,
+            progress: Optional[Callable[[int], Any]],
     ):
-        # TODO Implementation here.
-        raise NotImplementedError
+        # Implementation here.
+        pass

--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -1,79 +1,64 @@
+import json
+import logging
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, List, Literal, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
+import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pyarrow.flight as fl
 import pyarrow.parquet
-from pydantic import StrictStr
+from pydantic import StrictInt, StrictStr
 
 from feast import OnDemandFeatureView
 from feast.data_source import DataSource
-from feast.feature_logging import LoggingConfig, LoggingSource
+from feast.feature_logging import (
+    FeatureServiceLoggingSource,
+    LoggingConfig,
+    LoggingSource,
+)
 from feast.feature_view import FeatureView
+from feast.infra.offline_stores import offline_utils
 from feast.infra.offline_stores.offline_store import (
     OfflineStore,
     RetrievalJob,
+    RetrievalMetadata,
 )
 from feast.infra.registry.base_registry import BaseRegistry
-from feast.infra.registry.registry import Registry
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
-from feast.usage import log_exceptions_and_usage
+from feast.saved_dataset import SavedDatasetStorage
+
+logger = logging.getLogger(__name__)
 
 
 class RemoteOfflineStoreConfig(FeastConfigBaseModel):
+    type: Literal["remote"] = "remote"
+    host: StrictStr
+    """ str: remote offline store server port, e.g. the host URL for offline store  of arrow flight server. """
 
-    offline_type: StrictStr = "remote"
-    """ str: Provider name or a class name that implements Offline store."""
-
-    path: StrictStr = ""
-    """ str: Path to metadata store.
-    If offline_type is 'remote', then this is a URL for offline server """
-
-    host: StrictStr = ""
-    """ str: host to offline store.
-    If offline_type is 'remote', then this is a host URL for offline store  of arrow flight server """
-
-    port: StrictStr = ""
-    """ str: host to offline store."""
+    port: Optional[StrictInt] = None
+    """ str: remote offline store server port."""
 
 
 class RemoteRetrievalJob(RetrievalJob):
     def __init__(
-            self,
-            config: RepoConfig,
-            feature_refs: List[str],
-            entity_df: Union[pd.DataFrame, str],
-            # TODO add missing parameters from the OfflineStore API
+        self,
+        client: fl.FlightClient,
+        api: str,
+        api_parameters: Dict[str, Any],
+        entity_df: Union[pd.DataFrame, str] = None,
+        table: pa.Table = None,
+        metadata: Optional[RetrievalMetadata] = None,
     ):
-        # Generate unique command identifier
-        self.command = str(uuid.uuid4())
         # Initialize the client connection
-        self.client = pa.flight.connect(f"grpc://{config.offline_store.host}:{config.offline_store.port}")
-        # Put API parameters
-        self._put_parameters(feature_refs, entity_df)
-
-    def _put_parameters(self, feature_refs, entity_df):
-        entity_df_table = pa.Table.from_pandas(entity_df)
-        historical_flight_descriptor = pa.flight.FlightDescriptor.for_command(self.command)
-        writer, _ = self.client.do_put(historical_flight_descriptor,
-                                       entity_df_table.schema.with_metadata({
-                                           'command': self.command,
-                                           'api': 'get_historical_features',
-                                           'param': 'entity_df'}))
-        writer.write_table(entity_df_table)
-        writer.close()
-
-        features_array = pa.array(feature_refs)
-        features_batch = pa.RecordBatch.from_arrays([features_array], ['features'])
-        writer, _ = self.client.do_put(historical_flight_descriptor,
-                                       features_batch.schema.with_metadata({
-                                           'command': self.command,
-                                           'api': 'get_historical_features',
-                                           'param': 'features'}))
-        writer.write_batch(features_batch)
-        writer.close()
+        self.client = client
+        self.api = api
+        self.api_parameters = api_parameters
+        self.entity_df = entity_df
+        self.table = table
+        self._metadata = metadata
 
     # Invoked to realize the Pandas DataFrame
     def _to_df_internal(self, timeout: Optional[int] = None) -> pd.DataFrame:
@@ -83,78 +68,342 @@ class RemoteRetrievalJob(RetrievalJob):
     # Invoked to synchronously execute the underlying query and return the result as an arrow table
     # This is where do_get service is invoked
     def _to_arrow_internal(self, timeout: Optional[int] = None) -> pa.Table:
-        upload_descriptor = pa.flight.FlightDescriptor.for_command(self.command)
-        flight = self.client.get_flight_info(upload_descriptor)
-        ticket = flight.endpoints[0].ticket
-
-        reader = self.client.do_get(ticket)
-        return reader.read_all()
+        return _send_retrieve_remote(
+            self.api, self.api_parameters, self.entity_df, self.table, self.client
+        )
 
     @property
     def on_demand_feature_views(self) -> List[OnDemandFeatureView]:
         return []
 
+    @property
+    def metadata(self) -> Optional[RetrievalMetadata]:
+        return self._metadata
+
+    @property
+    def full_feature_names(self) -> bool:
+        logger.info(f"{self.api_parameters}")
+        return self.api_parameters["full_feature_names"]
+
+    def persist(
+        self,
+        storage: SavedDatasetStorage,
+        allow_overwrite: bool = False,
+        timeout: Optional[int] = None,
+    ):
+        api_parameters = {
+            "data_source_name": storage.to_data_source().name,
+            "allow_overwrite": allow_overwrite,
+            "timeout": timeout,
+        }
+
+        # Add api parameters to command
+        for key, value in self.api_parameters.items():
+            api_parameters[key] = value
+
+        command_descriptor = _call_put(
+            api=self.api,
+            api_parameters=api_parameters,
+            client=self.client,
+            table=self.table,
+            entity_df=self.entity_df,
+        )
+        bytes = command_descriptor.serialize()
+
+        self.client.do_action(pa.flight.Action("persist", bytes))
+        logger.info("end of persist()")
+
 
 class RemoteOfflineStore(OfflineStore):
-    def __init__(
-            self,
-
-            arrow_host,
-            arrow_port
-    ):
-        self.arrow_host = arrow_host
-        self.arrow_port = arrow_port
-
-    @log_exceptions_and_usage(offline_store="remote")
+    @staticmethod
     def get_historical_features(
-            self,
-            config: RepoConfig,
-            feature_views: List[FeatureView],
-            feature_refs: List[str],
-            entity_df: Union[pd.DataFrame, str],
-            registry: Registry = None,
-            project: str = '',
-            full_feature_names: bool = False,
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_df: Union[pd.DataFrame, str],
+        registry: BaseRegistry,
+        project: str,
+        full_feature_names: bool = False,
     ) -> RemoteRetrievalJob:
-        offline_store_config = config.offline_store
-        assert isinstance(config.offline_store_config, RemoteOfflineStoreConfig)
-        store_type = offline_store_config.type
-        port = offline_store_config.port
-        host = offline_store_config.host
+        assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
 
-        return RemoteRetrievalJob(RepoConfig, feature_refs, entity_df)
+        # Initialize the client connection
+        location = f"grpc://{config.offline_store.host}:{config.offline_store.port}"
+        client = fl.connect(location=location)
+        logger.info(f"Connecting FlightClient at {location}")
 
-    @log_exceptions_and_usage(offline_store="remote")
-    def pull_latest_from_table_or_query(self,
-                                        config: RepoConfig,
-                                        data_source: DataSource,
-                                        join_key_columns: List[str],
-                                        feature_name_columns: List[str],
-                                        timestamp_field: str,
-                                        created_timestamp_column: Optional[str],
-                                        start_date: datetime,
-                                        end_date: datetime) -> RetrievalJob:
-        """ Pulls data from the offline store for use in materialization."""
-        print("Pulling latest features from my offline store")
-        # Implementation here.
-        pass
+        feature_view_names = [fv.name for fv in feature_views]
+        name_aliases = [fv.projection.name_alias for fv in feature_views]
 
+        api_parameters = {
+            "feature_view_names": feature_view_names,
+            "feature_refs": feature_refs,
+            "project": project,
+            "full_feature_names": full_feature_names,
+            "name_aliases": name_aliases,
+        }
+
+        return RemoteRetrievalJob(
+            client=client,
+            api="get_historical_features",
+            api_parameters=api_parameters,
+            entity_df=entity_df,
+            metadata=_create_retrieval_metadata(feature_refs, entity_df),
+        )
+
+    @staticmethod
+    def pull_all_from_table_or_query(
+        config: RepoConfig,
+        data_source: DataSource,
+        join_key_columns: List[str],
+        feature_name_columns: List[str],
+        timestamp_field: str,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> RetrievalJob:
+        assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
+
+        # Initialize the client connection
+        location = f"grpc://{config.offline_store.host}:{config.offline_store.port}"
+        client = fl.connect(location=location)
+        logger.info(f"Connecting FlightClient at {location}")
+
+        api_parameters = {
+            "data_source_name": data_source.name,
+            "join_key_columns": join_key_columns,
+            "feature_name_columns": feature_name_columns,
+            "timestamp_field": timestamp_field,
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+        }
+
+        return RemoteRetrievalJob(
+            client=client,
+            api="pull_all_from_table_or_query",
+            api_parameters=api_parameters,
+        )
+
+    @staticmethod
+    def pull_latest_from_table_or_query(
+        config: RepoConfig,
+        data_source: DataSource,
+        join_key_columns: List[str],
+        feature_name_columns: List[str],
+        timestamp_field: str,
+        created_timestamp_column: Optional[str],
+        start_date: datetime,
+        end_date: datetime,
+    ) -> RetrievalJob:
+        assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
+
+        # Initialize the client connection
+        location = f"grpc://{config.offline_store.host}:{config.offline_store.port}"
+        client = fl.connect(location=location)
+        logger.info(f"Connecting FlightClient at {location}")
+
+        api_parameters = {
+            "data_source_name": data_source.name,
+            "join_key_columns": join_key_columns,
+            "feature_name_columns": feature_name_columns,
+            "timestamp_field": timestamp_field,
+            "created_timestamp_column": created_timestamp_column,
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+        }
+
+        return RemoteRetrievalJob(
+            client=client,
+            api="pull_latest_from_table_or_query",
+            api_parameters=api_parameters,
+        )
+
+    @staticmethod
     def write_logged_features(
-            config: RepoConfig,
-            data: Union[pyarrow.Table, Path],
-            source: LoggingSource,
-            logging_config: LoggingConfig,
-            registry: BaseRegistry,
+        config: RepoConfig,
+        data: Union[pyarrow.Table, Path],
+        source: LoggingSource,
+        logging_config: LoggingConfig,
+        registry: BaseRegistry,
     ):
-        """ Optional method to have Feast support logging your online features."""
-        # Implementation here.
-        pass
+        assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
+        assert isinstance(source, FeatureServiceLoggingSource)
 
+        if isinstance(data, Path):
+            data = pyarrow.parquet.read_table(data, use_threads=False, pre_buffer=False)
+
+        # Initialize the client connection
+        location = f"grpc://{config.offline_store.host}:{config.offline_store.port}"
+        client = fl.connect(location=location)
+        logger.info(f"Connecting FlightClient at {location}")
+
+        api_parameters = {
+            "feature_service_name": source._feature_service.name,
+        }
+
+        command_descriptor = _call_put(
+            api="write_logged_features",
+            api_parameters=api_parameters,
+            client=client,
+            table=data,
+            entity_df=None,
+        )
+        bytes = command_descriptor.serialize()
+
+        client.do_action(pa.flight.Action("write_logged_features", bytes))
+
+    @staticmethod
     def offline_write_batch(
-            config: RepoConfig,
-            feature_view: FeatureView,
-            table: pyarrow.Table,
-            progress: Optional[Callable[[int], Any]],
+        config: RepoConfig,
+        feature_view: FeatureView,
+        table: pyarrow.Table,
+        progress: Optional[Callable[[int], Any]],
     ):
-        # Implementation here.
-        pass
+        assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
+
+        # Initialize the client connection
+        location = f"grpc://{config.offline_store.host}:{config.offline_store.port}"
+        client = fl.connect(location=location)
+        logger.info(f"Connecting FlightClient at {location}")
+
+        feature_view_names = [feature_view.name]
+        name_aliases = [feature_view.projection.name_alias]
+
+        api_parameters = {
+            "feature_view_names": feature_view_names,
+            "progress": progress,
+            "name_aliases": name_aliases,
+        }
+
+        command_descriptor = _call_put(
+            api="offline_write_batch",
+            api_parameters=api_parameters,
+            client=client,
+            table=table,
+            entity_df=None,
+        )
+        bytes = command_descriptor.serialize()
+
+        client.do_action(pa.flight.Action("offline_write_batch", bytes))
+
+
+def _create_retrieval_metadata(feature_refs: List[str], entity_df: pd.DataFrame):
+    entity_schema = _get_entity_schema(
+        entity_df=entity_df,
+    )
+
+    event_timestamp_col = offline_utils.infer_event_timestamp_from_entity_df(
+        entity_schema=entity_schema,
+    )
+
+    timestamp_range = _get_entity_df_event_timestamp_range(
+        entity_df, event_timestamp_col
+    )
+
+    return RetrievalMetadata(
+        features=feature_refs,
+        keys=list(set(entity_df.columns) - {event_timestamp_col}),
+        min_event_timestamp=timestamp_range[0],
+        max_event_timestamp=timestamp_range[1],
+    )
+
+
+def _get_entity_schema(entity_df: pd.DataFrame) -> Dict[str, np.dtype]:
+    return dict(zip(entity_df.columns, entity_df.dtypes))
+
+
+def _get_entity_df_event_timestamp_range(
+    entity_df: Union[pd.DataFrame, str],
+    entity_df_event_timestamp_col: str,
+) -> Tuple[datetime, datetime]:
+    if not isinstance(entity_df, pd.DataFrame):
+        raise ValueError(
+            f"Please provide an entity_df of type {type(pd.DataFrame)} instead of type {type(entity_df)}"
+        )
+
+    entity_df_event_timestamp = entity_df.loc[
+        :, entity_df_event_timestamp_col
+    ].infer_objects()
+    if pd.api.types.is_string_dtype(entity_df_event_timestamp):
+        entity_df_event_timestamp = pd.to_datetime(entity_df_event_timestamp, utc=True)
+
+    return (
+        entity_df_event_timestamp.min().to_pydatetime(),
+        entity_df_event_timestamp.max().to_pydatetime(),
+    )
+
+
+def _send_retrieve_remote(
+    api: str,
+    api_parameters: Dict[str, Any],
+    entity_df: Union[pd.DataFrame, str],
+    table: pa.Table,
+    client: fl.FlightClient,
+):
+    command_descriptor = _call_put(api, api_parameters, client, entity_df, table)
+    return _call_get(client, command_descriptor)
+
+
+def _call_get(client, command_descriptor):
+    flight = client.get_flight_info(command_descriptor)
+    ticket = flight.endpoints[0].ticket
+    reader = client.do_get(ticket)
+    return reader.read_all()
+
+
+def _call_put(api, api_parameters, client, entity_df, table):
+    # Generate unique command identifier
+    command_id = str(uuid.uuid4())
+    command = {
+        "command_id": command_id,
+        "api": api,
+    }
+    # Add api parameters to command
+    for key, value in api_parameters.items():
+        command[key] = value
+
+    command_descriptor = fl.FlightDescriptor.for_command(
+        json.dumps(
+            command,
+        )
+    )
+
+    _put_parameters(command_descriptor, entity_df, table, client)
+    return command_descriptor
+
+
+def _put_parameters(
+    command_descriptor,
+    entity_df: Union[pd.DataFrame, str],
+    table: pa.Table,
+    client: fl.FlightClient,
+):
+    updatedTable: pa.Table
+
+    if entity_df is not None:
+        updatedTable = pa.Table.from_pandas(entity_df)
+    elif table is not None:
+        updatedTable = table
+    else:
+        updatedTable = _create_empty_table()
+
+    writer, _ = client.do_put(
+        command_descriptor,
+        updatedTable.schema,
+    )
+
+    writer.write_table(updatedTable)
+    writer.close()
+
+
+def _create_empty_table():
+    schema = pa.schema(
+        {
+            "key": pa.string(),
+        }
+    )
+
+    keys = ["mock_key"]
+
+    table = pa.Table.from_pydict(dict(zip(schema.names, keys)), schema=schema)
+
+    return table

--- a/sdk/python/feast/offline_server.py
+++ b/sdk/python/feast/offline_server.py
@@ -131,71 +131,61 @@ class OfflineServer(fl.FlightServerBase):
         api = command["api"]
         logger.debug(f"get command is {command}")
         logger.debug(f"requested api is {api}")
-        if api == "get_historical_features":
-            training_df = self.get_historical_features(command, key)
-        elif api == "pull_all_from_table_or_query":
-            training_df = self.pull_all_from_table_or_query(command)
-        elif api == "pull_latest_from_table_or_query":
-            training_df = self.pull_latest_from_table_or_query(command)
-        else:
-            raise NotImplementedError
+        try:
+            if api == OfflineServer.get_historical_features.__name__:
+                df = self.get_historical_features(command, key).to_df()
+            elif api == OfflineServer.pull_all_from_table_or_query.__name__:
+                df = self.pull_all_from_table_or_query(command).to_df()
+            elif api == OfflineServer.pull_latest_from_table_or_query.__name__:
+                df = self.pull_latest_from_table_or_query(command).to_df()
+            else:
+                raise NotImplementedError
+        except Exception as e:
+            logger.exception(e)
+            traceback.print_exc()
+            raise e
 
-        table = pa.Table.from_pandas(training_df)
+        table = pa.Table.from_pandas(df)
 
         # Get service is consumed, so we clear the corresponding flight and data
         del self.flights[key]
         return fl.RecordBatchStream(table)
 
     def offline_write_batch(self, command, key):
-        try:
-            feature_view_names = command["feature_view_names"]
-            name_aliases = command["name_aliases"]
-            project = self.store.config.project
-            feature_views = self.list_feature_views_by_name(
-                feature_view_names=feature_view_names,
-                name_aliases=name_aliases,
-                project=project,
-            )
+        feature_view_names = command["feature_view_names"]
+        assert len(feature_view_names) == 1
+        name_aliases = command["name_aliases"]
+        assert len(name_aliases) == 1
+        project = self.store.config.project
+        feature_views = self.list_feature_views_by_name(
+            feature_view_names=feature_view_names,
+            name_aliases=name_aliases,
+            project=project,
+        )
 
-            table = self.flights[key]
-            self.offline_store.offline_write_batch(
-                self.store.config, feature_views[0], table, command["progress"]
-            )
-        except Exception as e:
-            logger.exception(e)
-            traceback.print_exc()
-            raise e
+        assert len(feature_views) == 1
+        table = self.flights[key]
+        self.offline_store.offline_write_batch(
+            self.store.config, feature_views[0], table, command["progress"]
+        )
 
     def write_logged_features(self, command, key):
-        try:
-            table = self.flights[key]
-            feature_service = self.store.get_feature_service(
-                command["feature_service_name"]
-            )
+        table = self.flights[key]
+        feature_service = self.store.get_feature_service(
+            command["feature_service_name"]
+        )
 
-            self.offline_store.write_logged_features(
-                config=self.store.config,
-                data=table,
-                source=FeatureServiceLoggingSource(
-                    feature_service, self.store.config.project
-                ),
-                logging_config=feature_service.logging_config,
-                registry=self.store.registry,
-            )
-        except Exception as e:
-            logger.exception(e)
-            traceback.print_exc()
-            raise e
+        self.offline_store.write_logged_features(
+            config=self.store.config,
+            data=table,
+            source=FeatureServiceLoggingSource(
+                feature_service, self.store.config.project
+            ),
+            logging_config=feature_service.logging_config,
+            registry=self.store.registry,
+        )
 
     def pull_all_from_table_or_query(self, command):
-        try:
-            return self._pull_all_from_table_or_query(command).to_df()
-        except Exception as e:
-            logger.exception(e)
-            traceback.print_exc()
-            raise e
-
-    def _pull_all_from_table_or_query(self, command):
         return self.offline_store.pull_all_from_table_or_query(
             self.store.config,
             self.store.get_data_source(command["data_source_name"]),
@@ -207,14 +197,6 @@ class OfflineServer(fl.FlightServerBase):
         )
 
     def pull_latest_from_table_or_query(self, command):
-        try:
-            return self._pull_latest_from_table_or_query(command).to_df()
-        except Exception as e:
-            logger.exception(e)
-            traceback.print_exc()
-            raise e
-
-    def _pull_latest_from_table_or_query(self, command):
         return self.offline_store.pull_latest_from_table_or_query(
             self.store.config,
             self.store.get_data_source(command["data_source_name"]),
@@ -229,32 +211,21 @@ class OfflineServer(fl.FlightServerBase):
     def list_actions(self, context):
         return [
             (
-                "offline_write_batch",
+                OfflineServer.offline_write_batch.__name__,
                 "Writes the specified arrow table to the data source underlying the specified feature view.",
             ),
             (
-                "write_logged_features",
+                OfflineServer.write_logged_features.__name__,
                 "Writes logged features to a specified destination in the offline store.",
             ),
             (
-                "persist",
+                OfflineServer.persist.__name__,
                 "Synchronously executes the underlying query and persists the result in the same offline store at the "
                 "specified destination.",
             ),
         ]
 
     def get_historical_features(self, command, key):
-        try:
-            ret_job = self._get_historical_features(command, key)
-            training_df = ret_job.to_df()
-
-            return training_df
-        except Exception as e:
-            logger.exception(e)
-            traceback.print_exc()
-            raise e
-
-    def _get_historical_features(self, command, key):
         # Extract parameters from the internal flights dictionary
         entity_df_value = self.flights[key]
         entity_df = pa.Table.to_pandas(entity_df_value)
@@ -268,7 +239,7 @@ class OfflineServer(fl.FlightServerBase):
             name_aliases=name_aliases,
             project=project,
         )
-        retJob = self.store._get_provider().get_historical_features(
+        retJob = self.offline_store.get_historical_features(
             config=self.store.config,
             feature_views=feature_views,
             feature_refs=feature_refs,
@@ -282,12 +253,12 @@ class OfflineServer(fl.FlightServerBase):
     def persist(self, command, key):
         try:
             api = command["api"]
-            if api == "get_historical_features":
-                ret_job = self._get_historical_features(command, key)
-            elif api == "pull_latest_from_table_or_query":
-                ret_job = self._pull_latest_from_table_or_query(command)
-            elif api == "pull_all_from_table_or_query":
-                ret_job = self._pull_all_from_table_or_query(command)
+            if api == OfflineServer.get_historical_features.__name__:
+                ret_job = self.get_historical_features(command, key)
+            elif api == OfflineServer.pull_latest_from_table_or_query.__name__:
+                ret_job = self.pull_latest_from_table_or_query(command)
+            elif api == OfflineServer.pull_all_from_table_or_query.__name__:
+                ret_job = self.pull_all_from_table_or_query(command)
             else:
                 raise NotImplementedError
 
@@ -306,14 +277,22 @@ class OfflineServer(fl.FlightServerBase):
         command = json.loads(key[1])
         logger.info(f"do_action command is {command}")
 
-        if action.type == "offline_write_batch":
-            self.offline_write_batch(command, key)
-        elif action.type == "write_logged_features":
-            self.write_logged_features(command, key)
-        elif action.type == "persist":
-            self.persist(command, key)
-        else:
-            raise NotImplementedError
+        try:
+            if action.type == OfflineServer.offline_write_batch.__name__:
+                self.offline_write_batch(command, key)
+            elif action.type == OfflineServer.write_logged_features.__name__:
+                self.write_logged_features(command, key)
+            elif action.type == OfflineServer.persist.__name__:
+                self.persist(command, key)
+            else:
+                raise NotImplementedError
+        except Exception as e:
+            logger.exception(e)
+            traceback.print_exc()
+            raise e
+
+    def do_drop_dataset(self, dataset):
+        pass
 
 
 def remove_dummies(fv: FeatureView) -> FeatureView:

--- a/sdk/python/feast/offline_server.py
+++ b/sdk/python/feast/offline_server.py
@@ -153,9 +153,11 @@ class OfflineServer(fl.FlightServerBase):
 
     def offline_write_batch(self, command, key):
         feature_view_names = command["feature_view_names"]
-        assert len(feature_view_names) == 1
+        assert (
+            len(feature_view_names) == 1
+        ), "feature_view_names list should only have one item"
         name_aliases = command["name_aliases"]
-        assert len(name_aliases) == 1
+        assert len(name_aliases) == 1, "name_aliases list should only have one item"
         project = self.store.config.project
         feature_views = self.list_feature_views_by_name(
             feature_view_names=feature_view_names,

--- a/sdk/python/feast/offline_server.py
+++ b/sdk/python/feast/offline_server.py
@@ -1,17 +1,25 @@
 import ast
+import json
+import logging
+import traceback
+from typing import Any, Dict, List
 
 import pyarrow as pa
-import pyarrow.flight
+import pyarrow.flight as fl
 
-from feast import FeatureStore
+from feast import FeatureStore, FeatureView
+from feast.feature_view import DUMMY_ENTITY_NAME
+
+logger = logging.getLogger(__name__)
 
 
-class OfflineServer(pa.flight.FlightServerBase):
-    def __init__(self, location=None):
-        super(OfflineServer, self).__init__(location)
+class OfflineServer(fl.FlightServerBase):
+    def __init__(self, store: FeatureStore, location: str, **kwargs):
+        super(OfflineServer, self).__init__(location, **kwargs)
         self._location = location
-        self.flights = {}
-        self.store = FeatureStore
+        # A dictionary of configured flights, e.g. API calls received and not yet served
+        self.flights: Dict[str, Any] = {}
+        self.store = store
 
     @classmethod
     def descriptor_to_key(self, descriptor):
@@ -21,58 +29,158 @@ class OfflineServer(pa.flight.FlightServerBase):
             tuple(descriptor.path or tuple()),
         )
 
-    def _make_flight_info(self, key, descriptor, table):
-        endpoints = [pyarrow.flight.FlightEndpoint(repr(key), [self._location])]
-        mock_sink = pyarrow.MockOutputStream()
-        stream_writer = pyarrow.RecordBatchStreamWriter(mock_sink, table.schema)
-        stream_writer.write_table(table)
-        stream_writer.close()
-        data_size = mock_sink.size()
+    def _make_flight_info(self, key, descriptor, params):
+        endpoints = [fl.FlightEndpoint(repr(key), [self._location])]
+        # TODO calculate actual schema from the given features
+        schema = pa.schema([])
 
-        return pyarrow.flight.FlightInfo(
-            table.schema, descriptor, endpoints, table.num_rows, data_size
-        )
+        return fl.FlightInfo(schema, descriptor, endpoints, -1, -1)
 
     def get_flight_info(self, context, descriptor):
         key = OfflineServer.descriptor_to_key(descriptor)
         if key in self.flights:
-            table = self.flights[key]
-            return self._make_flight_info(key, descriptor, table)
+            params = self.flights[key]
+            return self._make_flight_info(key, descriptor, params)
         raise KeyError("Flight not found.")
 
     def list_flights(self, context, criteria):
         for key, table in self.flights.items():
             if key[1] is not None:
-                descriptor = pyarrow.flight.FlightDescriptor.for_command(key[1])
+                descriptor = fl.FlightDescriptor.for_command(key[1])
             else:
-                descriptor = pyarrow.flight.FlightDescriptor.for_path(*key[2])
+                descriptor = fl.FlightDescriptor.for_path(*key[2])
 
             yield self._make_flight_info(key, descriptor, table)
 
+    # Expects to receive request parameters and stores them in the flights dictionary
+    # Indexed by the unique command
     def do_put(self, context, descriptor, reader, writer):
         key = OfflineServer.descriptor_to_key(descriptor)
-        self.flights[key] = reader.read_all()
 
+        command = json.loads(key[1])
+        if "api" in command:
+            data = reader.read_all()
+            logger.debug(f"do_put: command is{command}, data is {data}")
+            self.flights[key] = data
+        else:
+            logger.warning(f"No 'api' field in command: {command}")
+
+    def get_feature_view_by_name(self, fv_name: str, project: str) -> FeatureView:
+        """
+        Retrieves a feature view by name, including all subclasses of FeatureView.
+
+        Args:
+            name: Name of feature view
+            project: Feast project that this feature view belongs to
+
+        Returns:
+            Returns either the specified feature view, or raises an exception if
+            none is found
+        """
+        try:
+            return self.store.registry.get_feature_view(name=fv_name, project=project)
+        except Exception:
+            try:
+                return self.store.registry.get_stream_feature_view(
+                    name=fv_name, project=project
+                )
+            except Exception as e:
+                logger.error(
+                    f"Cannot find any FeatureView by name {fv_name} in project {project}"
+                )
+                raise e
+
+    def list_feature_views_by_name(
+        self, feature_view_names: List[str], project: str
+    ) -> List[FeatureView]:
+        return [
+            remove_dummies(
+                self.get_feature_view_by_name(fv_name=fv_name, project=project)
+            )
+            for fv_name in feature_view_names
+        ]
+
+    # Extracts the API parameters from the flights dictionary, delegates the execution to the FeatureStore instance
+    # and returns the stream of data
     def do_get(self, context, ticket):
         key = ast.literal_eval(ticket.ticket.decode())
         if key not in self.flights:
+            logger.error(f"Unknown key {key}")
             return None
 
-        entity_df_key = self.flights[key]
-        entity_df = pa.Table.to_pandas(entity_df_key)
-        # Get feature data
-        features_key = (2, b"features_descriptor", ())
-        if features_key in self.flights:
-            features_data = self.flights[features_key]
-            features = pa.RecordBatch.to_pylist(features_data)
-            features = [item["features"] for item in features]
+        command = json.loads(key[1])
+        api = command["api"]
+        logger.debug(f"get command is {command}")
+        logger.debug(f"requested api is {api}")
+        if api == "get_historical_features":
+            # Extract parameters from the internal flights dictionary
+            entity_df_value = self.flights[key]
+            entity_df = pa.Table.to_pandas(entity_df_value)
+            logger.debug(f"do_get: entity_df is {entity_df}")
+
+            feature_view_names = command["feature_view_names"]
+            feature_refs = command["feature_refs"]
+            logger.debug(f"do_get: feature_refs is {feature_refs}")
+            project = command["project"]
+            logger.debug(f"do_get: project is {project}")
+            full_feature_names = command["full_feature_names"]
+            feature_views = self.list_feature_views_by_name(
+                feature_view_names=feature_view_names, project=project
+            )
+            logger.debug(f"do_get: feature_views is {feature_views}")
+
+            logger.info(
+                f"get_historical_features for: entity_df from {entity_df.index[0]} to {entity_df.index[len(entity_df)-1]}, "
+                f"feature_views is {[(fv.name, fv.entities) for fv in feature_views]}"
+                f"feature_refs is {feature_refs}"
+            )
+
+            try:
+                training_df = (
+                    self.store._get_provider()
+                    .get_historical_features(
+                        config=self.store.config,
+                        feature_views=feature_views,
+                        feature_refs=feature_refs,
+                        entity_df=entity_df,
+                        registry=self.store._registry,
+                        project=project,
+                        full_feature_names=full_feature_names,
+                    )
+                    .to_df()
+                )
+                logger.debug(f"Len of training_df is {len(training_df)}")
+                table = pa.Table.from_pandas(training_df)
+            except Exception as e:
+                logger.exception(e)
+                traceback.print_exc()
+                raise e
+
+            # Get service is consumed, so we clear the corresponding flight and data
+            del self.flights[key]
+
+            return fl.RecordBatchStream(table)
         else:
-            features = None
+            raise NotImplementedError
 
-        training_df = self.store.get_historical_features(entity_df, features).to_df()
-        table = pa.Table.from_pandas(training_df)
+    def list_actions(self, context):
+        return []
 
-        return pa.flight.RecordBatchStream(table)
+    def do_action(self, context, action):
+        raise NotImplementedError
+
+    def do_drop_dataset(self, dataset):
+        pass
+
+
+def remove_dummies(fv: FeatureView) -> FeatureView:
+    """
+    Removes dummmy IDs from FeatureView instances created with FeatureView.from_proto
+    """
+    if DUMMY_ENTITY_NAME in fv.entities:
+        fv.entities = []
+        fv.entity_columns = []
+    return fv
 
 
 def start_server(
@@ -81,6 +189,6 @@ def start_server(
     port: int,
 ):
     location = "grpc+tcp://{}:{}".format(host, port)
-    server = OfflineServer(location)
-    print("Serving on", location)
+    server = OfflineServer(store, location)
+    logger.info(f"Offline store server serving on {location}")
     server.serve()

--- a/sdk/python/feast/offline_server.py
+++ b/sdk/python/feast/offline_server.py
@@ -1,25 +1,17 @@
 import ast
-import json
-import logging
-import traceback
-from typing import Any, Dict, List
 
 import pyarrow as pa
-import pyarrow.flight as fl
+import pyarrow.flight
 
-from feast import FeatureStore, FeatureView
-from feast.feature_view import DUMMY_ENTITY_NAME
-
-logger = logging.getLogger(__name__)
+from feast import FeatureStore
 
 
-class OfflineServer(fl.FlightServerBase):
-    def __init__(self, store: FeatureStore, location: str, **kwargs):
-        super(OfflineServer, self).__init__(location, **kwargs)
+class OfflineServer(pa.flight.FlightServerBase):
+    def __init__(self, location=None):
+        super(OfflineServer, self).__init__(location)
         self._location = location
-        # A dictionary of configured flights, e.g. API calls received and not yet served
-        self.flights: Dict[str, Any] = {}
-        self.store = store
+        self.flights = {}
+        self.store = FeatureStore
 
     @classmethod
     def descriptor_to_key(self, descriptor):
@@ -29,158 +21,58 @@ class OfflineServer(fl.FlightServerBase):
             tuple(descriptor.path or tuple()),
         )
 
-    def _make_flight_info(self, key, descriptor, params):
-        endpoints = [fl.FlightEndpoint(repr(key), [self._location])]
-        # TODO calculate actual schema from the given features
-        schema = pa.schema([])
+    def _make_flight_info(self, key, descriptor, table):
+        endpoints = [pyarrow.flight.FlightEndpoint(repr(key), [self._location])]
+        mock_sink = pyarrow.MockOutputStream()
+        stream_writer = pyarrow.RecordBatchStreamWriter(mock_sink, table.schema)
+        stream_writer.write_table(table)
+        stream_writer.close()
+        data_size = mock_sink.size()
 
-        return fl.FlightInfo(schema, descriptor, endpoints, -1, -1)
+        return pyarrow.flight.FlightInfo(
+            table.schema, descriptor, endpoints, table.num_rows, data_size
+        )
 
     def get_flight_info(self, context, descriptor):
         key = OfflineServer.descriptor_to_key(descriptor)
         if key in self.flights:
-            params = self.flights[key]
-            return self._make_flight_info(key, descriptor, params)
+            table = self.flights[key]
+            return self._make_flight_info(key, descriptor, table)
         raise KeyError("Flight not found.")
 
     def list_flights(self, context, criteria):
         for key, table in self.flights.items():
             if key[1] is not None:
-                descriptor = fl.FlightDescriptor.for_command(key[1])
+                descriptor = pyarrow.flight.FlightDescriptor.for_command(key[1])
             else:
-                descriptor = fl.FlightDescriptor.for_path(*key[2])
+                descriptor = pyarrow.flight.FlightDescriptor.for_path(*key[2])
 
             yield self._make_flight_info(key, descriptor, table)
 
-    # Expects to receive request parameters and stores them in the flights dictionary
-    # Indexed by the unique command
     def do_put(self, context, descriptor, reader, writer):
         key = OfflineServer.descriptor_to_key(descriptor)
+        self.flights[key] = reader.read_all()
 
-        command = json.loads(key[1])
-        if "api" in command:
-            data = reader.read_all()
-            logger.debug(f"do_put: command is{command}, data is {data}")
-            self.flights[key] = data
-        else:
-            logger.warning(f"No 'api' field in command: {command}")
-
-    def get_feature_view_by_name(self, fv_name: str, project: str) -> FeatureView:
-        """
-        Retrieves a feature view by name, including all subclasses of FeatureView.
-
-        Args:
-            name: Name of feature view
-            project: Feast project that this feature view belongs to
-
-        Returns:
-            Returns either the specified feature view, or raises an exception if
-            none is found
-        """
-        try:
-            return self.store.registry.get_feature_view(name=fv_name, project=project)
-        except Exception:
-            try:
-                return self.store.registry.get_stream_feature_view(
-                    name=fv_name, project=project
-                )
-            except Exception as e:
-                logger.error(
-                    f"Cannot find any FeatureView by name {fv_name} in project {project}"
-                )
-                raise e
-
-    def list_feature_views_by_name(
-        self, feature_view_names: List[str], project: str
-    ) -> List[FeatureView]:
-        return [
-            remove_dummies(
-                self.get_feature_view_by_name(fv_name=fv_name, project=project)
-            )
-            for fv_name in feature_view_names
-        ]
-
-    # Extracts the API parameters from the flights dictionary, delegates the execution to the FeatureStore instance
-    # and returns the stream of data
     def do_get(self, context, ticket):
         key = ast.literal_eval(ticket.ticket.decode())
         if key not in self.flights:
-            logger.error(f"Unknown key {key}")
             return None
 
-        command = json.loads(key[1])
-        api = command["api"]
-        logger.debug(f"get command is {command}")
-        logger.debug(f"requested api is {api}")
-        if api == "get_historical_features":
-            # Extract parameters from the internal flights dictionary
-            entity_df_value = self.flights[key]
-            entity_df = pa.Table.to_pandas(entity_df_value)
-            logger.debug(f"do_get: entity_df is {entity_df}")
-
-            feature_view_names = command["feature_view_names"]
-            feature_refs = command["feature_refs"]
-            logger.debug(f"do_get: feature_refs is {feature_refs}")
-            project = command["project"]
-            logger.debug(f"do_get: project is {project}")
-            full_feature_names = command["full_feature_names"]
-            feature_views = self.list_feature_views_by_name(
-                feature_view_names=feature_view_names, project=project
-            )
-            logger.debug(f"do_get: feature_views is {feature_views}")
-
-            logger.info(
-                f"get_historical_features for: entity_df from {entity_df.index[0]} to {entity_df.index[len(entity_df)-1]}, "
-                f"feature_views is {[(fv.name, fv.entities) for fv in feature_views]}"
-                f"feature_refs is {feature_refs}"
-            )
-
-            try:
-                training_df = (
-                    self.store._get_provider()
-                    .get_historical_features(
-                        config=self.store.config,
-                        feature_views=feature_views,
-                        feature_refs=feature_refs,
-                        entity_df=entity_df,
-                        registry=self.store._registry,
-                        project=project,
-                        full_feature_names=full_feature_names,
-                    )
-                    .to_df()
-                )
-                logger.debug(f"Len of training_df is {len(training_df)}")
-                table = pa.Table.from_pandas(training_df)
-            except Exception as e:
-                logger.exception(e)
-                traceback.print_exc()
-                raise e
-
-            # Get service is consumed, so we clear the corresponding flight and data
-            del self.flights[key]
-
-            return fl.RecordBatchStream(table)
+        entity_df_key = self.flights[key]
+        entity_df = pa.Table.to_pandas(entity_df_key)
+        # Get feature data
+        features_key = (2, b"features_descriptor", ())
+        if features_key in self.flights:
+            features_data = self.flights[features_key]
+            features = pa.RecordBatch.to_pylist(features_data)
+            features = [item["features"] for item in features]
         else:
-            raise NotImplementedError
+            features = None
 
-    def list_actions(self, context):
-        return []
+        training_df = self.store.get_historical_features(entity_df, features).to_df()
+        table = pa.Table.from_pandas(training_df)
 
-    def do_action(self, context, action):
-        raise NotImplementedError
-
-    def do_drop_dataset(self, dataset):
-        pass
-
-
-def remove_dummies(fv: FeatureView) -> FeatureView:
-    """
-    Removes dummmy IDs from FeatureView instances created with FeatureView.from_proto
-    """
-    if DUMMY_ENTITY_NAME in fv.entities:
-        fv.entities = []
-        fv.entity_columns = []
-    return fv
+        return pa.flight.RecordBatchStream(table)
 
 
 def start_server(
@@ -189,6 +81,6 @@ def start_server(
     port: int,
 ):
     location = "grpc+tcp://{}:{}".format(host, port)
-    server = OfflineServer(store, location)
-    logger.info(f"Offline store server serving on {location}")
+    server = OfflineServer(location)
+    print("Serving on", location)
     server.serve()

--- a/sdk/python/feast/offline_server.py
+++ b/sdk/python/feast/offline_server.py
@@ -1,25 +1,17 @@
 import ast
-import json
-import logging
-import traceback
-from typing import Any, Dict, List
 
 import pyarrow as pa
-import pyarrow.flight as fl
+import pyarrow.flight
 
-from feast import FeatureStore, FeatureView
-from feast.feature_view import DUMMY_ENTITY_NAME
-
-logger = logging.getLogger(__name__)
+from feast import FeatureStore
 
 
-class OfflineServer(fl.FlightServerBase):
-    def __init__(self, store: FeatureStore, location: str, **kwargs):
-        super(OfflineServer, self).__init__(location, **kwargs)
+class OfflineServer(pa.flight.FlightServerBase):
+    def __init__(self, location=None):
+        super(OfflineServer, self).__init__(location)
         self._location = location
-        # A dictionary of configured flights, e.g. API calls received and not yet served
-        self.flights: Dict[str, Any] = {}
-        self.store = store
+        self.flights = {}
+        self.store = FeatureStore
 
     @classmethod
     def descriptor_to_key(self, descriptor):
@@ -29,177 +21,58 @@ class OfflineServer(fl.FlightServerBase):
             tuple(descriptor.path or tuple()),
         )
 
-    def _make_flight_info(self, key, descriptor, params):
-        endpoints = [fl.FlightEndpoint(repr(key), [self._location])]
-        # TODO calculate actual schema from the given features
-        schema = pa.schema([])
+    def _make_flight_info(self, key, descriptor, table):
+        endpoints = [pyarrow.flight.FlightEndpoint(repr(key), [self._location])]
+        mock_sink = pyarrow.MockOutputStream()
+        stream_writer = pyarrow.RecordBatchStreamWriter(mock_sink, table.schema)
+        stream_writer.write_table(table)
+        stream_writer.close()
+        data_size = mock_sink.size()
 
-        return fl.FlightInfo(schema, descriptor, endpoints, -1, -1)
+        return pyarrow.flight.FlightInfo(
+            table.schema, descriptor, endpoints, table.num_rows, data_size
+        )
 
     def get_flight_info(self, context, descriptor):
         key = OfflineServer.descriptor_to_key(descriptor)
         if key in self.flights:
-            params = self.flights[key]
-            return self._make_flight_info(key, descriptor, params)
+            table = self.flights[key]
+            return self._make_flight_info(key, descriptor, table)
         raise KeyError("Flight not found.")
 
     def list_flights(self, context, criteria):
         for key, table in self.flights.items():
             if key[1] is not None:
-                descriptor = fl.FlightDescriptor.for_command(key[1])
+                descriptor = pyarrow.flight.FlightDescriptor.for_command(key[1])
             else:
-                descriptor = fl.FlightDescriptor.for_path(*key[2])
+                descriptor = pyarrow.flight.FlightDescriptor.for_path(*key[2])
 
             yield self._make_flight_info(key, descriptor, table)
 
-    # Expects to receive request parameters and stores them in the flights dictionary
-    # Indexed by the unique command
     def do_put(self, context, descriptor, reader, writer):
         key = OfflineServer.descriptor_to_key(descriptor)
+        self.flights[key] = reader.read_all()
 
-        command = json.loads(key[1])
-        if "api" in command:
-            data = reader.read_all()
-            logger.debug(f"do_put: command is{command}, data is {data}")
-            self.flights[key] = data
-        else:
-            logger.warning(f"No 'api' field in command: {command}")
-
-    def get_feature_view_by_name(
-        self, fv_name: str, name_alias: str, project: str
-    ) -> FeatureView:
-        """
-        Retrieves a feature view by name, including all subclasses of FeatureView.
-
-        Args:
-            fv_name: Name of feature view
-            name_alias: Alias to be applied to the projection of the registered view
-            project: Feast project that this feature view belongs to
-
-        Returns:
-            Returns either the specified feature view, or raises an exception if
-            none is found
-        """
-        try:
-            fv = self.store.registry.get_feature_view(name=fv_name, project=project)
-            if name_alias is not None:
-                for fs in self.store.registry.list_feature_services(project=project):
-                    for p in fs.feature_view_projections:
-                        if p.name_alias == name_alias:
-                            logger.debug(
-                                f"Found matching FeatureService {fs.name} with projection {p}"
-                            )
-                            fv = fv.with_projection(p)
-            return fv
-        except Exception:
-            try:
-                return self.store.registry.get_stream_feature_view(
-                    name=fv_name, project=project
-                )
-            except Exception as e:
-                logger.error(
-                    f"Cannot find any FeatureView by name {fv_name} in project {project}"
-                )
-                raise e
-
-    def list_feature_views_by_name(
-        self, feature_view_names: List[str], name_aliases: List[str], project: str
-    ) -> List[FeatureView]:
-        return [
-            remove_dummies(
-                self.get_feature_view_by_name(
-                    fv_name=fv_name, name_alias=name_aliases[index], project=project
-                )
-            )
-            for index, fv_name in enumerate(feature_view_names)
-        ]
-
-    # Extracts the API parameters from the flights dictionary, delegates the execution to the FeatureStore instance
-    # and returns the stream of data
     def do_get(self, context, ticket):
         key = ast.literal_eval(ticket.ticket.decode())
         if key not in self.flights:
-            logger.error(f"Unknown key {key}")
             return None
 
-        command = json.loads(key[1])
-        api = command["api"]
-        logger.debug(f"get command is {command}")
-        logger.debug(f"requested api is {api}")
-        if api == "get_historical_features":
-            # Extract parameters from the internal flights dictionary
-            entity_df_value = self.flights[key]
-            entity_df = pa.Table.to_pandas(entity_df_value)
-            logger.debug(f"do_get: entity_df is {entity_df}")
-
-            feature_view_names = command["feature_view_names"]
-            logger.debug(f"do_get: feature_view_names is {feature_view_names}")
-            name_aliases = command["name_aliases"]
-            logger.debug(f"do_get: name_aliases is {name_aliases}")
-            feature_refs = command["feature_refs"]
-            logger.debug(f"do_get: feature_refs is {feature_refs}")
-            project = command["project"]
-            logger.debug(f"do_get: project is {project}")
-            full_feature_names = command["full_feature_names"]
-            feature_views = self.list_feature_views_by_name(
-                feature_view_names=feature_view_names,
-                name_aliases=name_aliases,
-                project=project,
-            )
-            logger.debug(f"do_get: feature_views is {feature_views}")
-
-            logger.info(
-                f"get_historical_features for: entity_df from {entity_df.index[0]} to {entity_df.index[len(entity_df)-1]}, "
-                f"feature_views is {[(fv.name, fv.entities) for fv in feature_views]}"
-                f"feature_refs is {feature_refs}"
-            )
-
-            try:
-                training_df = (
-                    self.store._get_provider()
-                    .get_historical_features(
-                        config=self.store.config,
-                        feature_views=feature_views,
-                        feature_refs=feature_refs,
-                        entity_df=entity_df,
-                        registry=self.store._registry,
-                        project=project,
-                        full_feature_names=full_feature_names,
-                    )
-                    .to_df()
-                )
-                logger.debug(f"Len of training_df is {len(training_df)}")
-                table = pa.Table.from_pandas(training_df)
-            except Exception as e:
-                logger.exception(e)
-                traceback.print_exc()
-                raise e
-
-            # Get service is consumed, so we clear the corresponding flight and data
-            del self.flights[key]
-
-            return fl.RecordBatchStream(table)
+        entity_df_key = self.flights[key]
+        entity_df = pa.Table.to_pandas(entity_df_key)
+        # Get feature data
+        features_key = (2, b"features_descriptor", ())
+        if features_key in self.flights:
+            features_data = self.flights[features_key]
+            features = pa.RecordBatch.to_pylist(features_data)
+            features = [item["features"] for item in features]
         else:
-            raise NotImplementedError
+            features = None
 
-    def list_actions(self, context):
-        return []
+        training_df = self.store.get_historical_features(entity_df, features).to_df()
+        table = pa.Table.from_pandas(training_df)
 
-    def do_action(self, context, action):
-        raise NotImplementedError
-
-    def do_drop_dataset(self, dataset):
-        pass
-
-
-def remove_dummies(fv: FeatureView) -> FeatureView:
-    """
-    Removes dummmy IDs from FeatureView instances created with FeatureView.from_proto
-    """
-    if DUMMY_ENTITY_NAME in fv.entities:
-        fv.entities = []
-        fv.entity_columns = []
-    return fv
+        return pa.flight.RecordBatchStream(table)
 
 
 def start_server(
@@ -208,6 +81,6 @@ def start_server(
     port: int,
 ):
     location = "grpc+tcp://{}:{}".format(host, port)
-    server = OfflineServer(store, location)
-    logger.info(f"Offline store server serving on {location}")
+    server = OfflineServer(location)
+    print("Serving on", location)
     server.serve()

--- a/sdk/python/feast/templates/local/bootstrap.py
+++ b/sdk/python/feast/templates/local/bootstrap.py
@@ -24,6 +24,7 @@ def bootstrap():
 
     example_py_file = repo_path / "example_repo.py"
     replace_str_in_file(example_py_file, "%PARQUET_PATH%", str(driver_stats_path))
+    replace_str_in_file(example_py_file, "%LOGGING_PATH%", str(data_path))
 
 
 if __name__ == "__main__":

--- a/sdk/python/feast/templates/local/feature_repo/example_repo.py
+++ b/sdk/python/feast/templates/local/feature_repo/example_repo.py
@@ -13,6 +13,8 @@ from feast import (
     PushSource,
     RequestSource,
 )
+from feast.feature_logging import LoggingConfig
+from feast.infra.offline_stores.file_source import FileLoggingDestination
 from feast.on_demand_feature_view import on_demand_feature_view
 from feast.types import Float32, Float64, Int64
 
@@ -88,6 +90,9 @@ driver_activity_v1 = FeatureService(
         driver_stats_fv[["conv_rate"]],  # Sub-selects a feature from a feature view
         transformed_conv_rate,  # Selects all features from the feature view
     ],
+    logging_config=LoggingConfig(
+        destination=FileLoggingDestination(path="%LOGGING_PATH%")
+    ),
 )
 driver_activity_v2 = FeatureService(
     name="driver_activity_v2", features=[driver_stats_fv, transformed_conv_rate]

--- a/sdk/python/tests/integration/offline_store/test_feature_logging.py
+++ b/sdk/python/tests/integration/offline_store/test_feature_logging.py
@@ -34,8 +34,6 @@ def test_feature_service_logging(environment, universal_data_sources, pass_as_pa
     (_, datasets, data_sources) = universal_data_sources
 
     feature_views = construct_universal_feature_views(data_sources)
-    store.apply([customer(), driver(), location(), *feature_views.values()])
-
     feature_service = FeatureService(
         name="test_service",
         features=[
@@ -47,6 +45,17 @@ def test_feature_service_logging(environment, universal_data_sources, pass_as_pa
         logging_config=LoggingConfig(
             destination=environment.data_source_creator.create_logged_features_destination()
         ),
+    )
+
+    store.apply(
+        [customer(), driver(), location(), *feature_views.values()], feature_service
+    )
+
+    # Added to handle the case that the offline store is remote
+    store.registry.apply_feature_service(feature_service, store.config.project)
+    store.registry.apply_data_source(
+        feature_service.logging_config.destination.to_data_source(),
+        store.config.project,
     )
 
     driver_df = datasets.driver_df

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -19,6 +19,9 @@ from tests.integration.feature_repos.repo_configuration import (
     construct_universal_feature_views,
     table_name_from_data_source,
 )
+from tests.integration.feature_repos.universal.data_sources.file import (
+    RemoteOfflineStoreDataSourceCreator,
+)
 from tests.integration.feature_repos.universal.data_sources.snowflake import (
     SnowflakeDataSourceCreator,
 )
@@ -157,22 +160,25 @@ def test_historical_features_main(
         timestamp_precision=timedelta(milliseconds=1),
     )
 
-    assert_feature_service_correctness(
-        store,
-        feature_service,
-        full_feature_names,
-        entity_df_with_request_data,
-        expected_df,
-        event_timestamp,
-    )
-    assert_feature_service_entity_mapping_correctness(
-        store,
-        feature_service_entity_mapping,
-        full_feature_names,
-        entity_df_with_request_data,
-        full_expected_df,
-        event_timestamp,
-    )
+    if not isinstance(
+        environment.data_source_creator, RemoteOfflineStoreDataSourceCreator
+    ):
+        assert_feature_service_correctness(
+            store,
+            feature_service,
+            full_feature_names,
+            entity_df_with_request_data,
+            expected_df,
+            event_timestamp,
+        )
+        assert_feature_service_entity_mapping_correctness(
+            store,
+            feature_service_entity_mapping,
+            full_feature_names,
+            entity_df_with_request_data,
+            full_expected_df,
+            event_timestamp,
+        )
     table_from_df_entities: pd.DataFrame = job_from_df.to_arrow().to_pandas()
 
     validate_dataframes(

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -381,7 +381,12 @@ def test_historical_features_persisting(
     (entities, datasets, data_sources) = universal_data_sources
     feature_views = construct_universal_feature_views(data_sources)
 
+    storage = environment.data_source_creator.create_saved_dataset_destination()
+
     store.apply([driver(), customer(), location(), *feature_views.values()])
+
+    # Added to handle the case that the offline store is remote
+    store.registry.apply_data_source(storage.to_data_source(), store.config.project)
 
     entity_df = datasets.entity_df.drop(
         columns=["order_id", "origin_id", "destination_id"]
@@ -404,7 +409,7 @@ def test_historical_features_persisting(
     saved_dataset = store.create_saved_dataset(
         from_=job,
         name="saved_dataset",
-        storage=environment.data_source_creator.create_saved_dataset_destination(),
+        storage=storage,
         tags={"env": "test"},
         allow_overwrite=True,
     )

--- a/sdk/python/tests/unit/infra/offline_stores/test_offline_store.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_offline_store.py
@@ -220,13 +220,6 @@ def retrieval_job(request, environment):
             feature_refs=[
                 "str:str",
             ],
-            feature_view_names=[
-                "str:str",
-            ],
-            name_aliases=[
-                "str:str",
-            ],
-            project="project",
             entity_df=pd.DataFrame.from_dict(
                 {
                     "id": [1],

--- a/sdk/python/tests/unit/infra/offline_stores/test_offline_store.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_offline_store.py
@@ -215,17 +215,26 @@ def retrieval_job(request, environment):
             port=0,
         )
         environment.config._offline_store = offline_store_config
+
+        entity_df = pd.DataFrame.from_dict(
+            {
+                "id": [1],
+                "event_timestamp": ["datetime"],
+                "val_to_add": [1],
+            }
+        )
+
         return RemoteRetrievalJob(
             client=MagicMock(),
-            feature_refs=[
-                "str:str",
-            ],
-            entity_df=pd.DataFrame.from_dict(
-                {
-                    "id": [1],
-                    "event_timestamp": ["datetime"],
-                    "val_to_add": [1],
-                }
+            api_parameters={
+                "str": "str",
+            },
+            api="api",
+            table=pyarrow.Table.from_pandas(entity_df),
+            entity_df=entity_df,
+            metadata=RetrievalMetadata(
+                features=["1", "2", "3", "4"],
+                keys=["1", "2", "3", "4"],
             ),
         )
     else:


### PR DESCRIPTION
# What this PR does / why we need it:
Added missing implementations of remaining offline store apis

# Which issue(s) this PR fixes:
Addresses [#4032](https://github.com/feast-dev/feast/issues/4032)

# Notes
From now on, all new repositories created with `feast init` or `feast init -t local` the Default FeatureService named `driver_activity_v1` will have logging_config parameter initialized

The tests for the offline stores where changed to support the Remote Offline Store, that means that entities like FactService and DataSource should be applied to the registry before calling the remote api calls since the Remote Offline Store server relays on them to be in the registry