### PR TITLE
Added filter_only flag to assert_permissions

### DIFF
--- a/sdk/python/feast/permissions/matcher.py
+++ b/sdk/python/feast/permissions/matcher.py
@@ -140,21 +140,21 @@ def resource_match_config(
 
 
 def actions_match_config(
-    actions: list[AuthzedAction],
+    requested_actions: list[AuthzedAction],
     allowed_actions: list[AuthzedAction],
 ) -> bool:
     """
     Match a list of actions against the actions defined in a permission configuration.
 
     Args:
-        actions: Alist of actions to be executed.
+        requested_actions: A list of actions to be executed.
         allowed_actions: The list of actions configured in the permission.
 
     Returns:
-        bool: `True` if all the given `actions` are defined in the `allowed_actions`.
-        Whatever the requested `actions`, it returns `True` if `allowed_actions` includes `AuthzedAction.ALL`
+        bool: `True` if all the given `requested_actions` are defined in the `allowed_actions`.
+        Whatever the `requested_actions`, it returns `True` if `allowed_actions` includes `AuthzedAction.ALL`
     """
     if AuthzedAction.ALL in allowed_actions:
         return True
 
-    return all(a in allowed_actions for a in actions)
+    return all(a in allowed_actions for a in requested_actions)

--- a/sdk/python/feast/permissions/permission.py
+++ b/sdk/python/feast/permissions/permission.py
@@ -127,14 +127,14 @@ class Permission(ABC):
             required_tags=self.required_tags,
         )
 
-    def match_actions(self, actions: list[AuthzedAction]) -> bool:
+    def match_actions(self, requested_actions: list[AuthzedAction]) -> bool:
         """
         Returns:
             `True` when the given actions are included in the permitted actions.
         """
         return actions_match_config(
             allowed_actions=self.actions,
-            actions=actions,
+            requested_actions=requested_actions,
         )
 
 

--- a/sdk/python/feast/permissions/security_manager.py
+++ b/sdk/python/feast/permissions/security_manager.py
@@ -61,7 +61,7 @@ class SecurityManager:
         resources: Union[list[FeastObject], FeastObject],
         actions: Union[AuthzedAction, List[AuthzedAction]],
         filter_only: bool = False,
-    ) -> list[FeastObject]:
+    ) -> Optional[Union[list[FeastObject], FeastObject]]:
         """
         Verify if the current user is authorized ro execute the requested actions on the given resources.
 
@@ -72,6 +72,10 @@ class SecurityManager:
             actions: The requested actions to be authorized.
             filter_only: If `True`, it removes unauthorized resources from the returned value, otherwise it raises a `PermissionError` the
             first unauthorized resource. Defaults to `False`.
+
+        Returns:
+            Union[list[FeastObject], FeastObject]: A filtered list of the permitted resources or the original `resources`, if permitted
+            (otherwise it's `None`).
 
         Raises:
             PermissionError: If the current user is not authorized to eecute all the requested actions on the given resources.
@@ -90,11 +94,23 @@ def assert_permissions(
     resources: Union[list[FeastObject], FeastObject],
     actions: Union[AuthzedAction, List[AuthzedAction]],
     filter_only: bool = False,
-) -> list[FeastObject]:
+) -> Optional[Union[list[FeastObject], FeastObject]]:
     """
     A utility function to invoke the `assert_permissions` method on the global security manager.
 
     If no global `SecurityManager` is defined, the execution is permitted.
+
+    Args:
+        resources: The resources for which we need to enforce authorized permission.
+        actions: The requested actions to be authorized.
+        filter_only: If `True`, it removes unauthorized resources from the returned value, otherwise it raises a `PermissionError` the
+        first unauthorized resource. Defaults to `False`.
+    Returns:
+        Union[list[FeastObject], FeastObject]: A filtered list of the permitted resources or the original `resources`, if permitted
+        (otherwise it's `None`).
+
+    Raises:
+        PermissionError: If the current user is not authorized to eecute the requested actions on the given resources (and `filter_only` is `False`).
     """
     sm = get_security_manager()
     if sm is None:

--- a/sdk/python/tests/unit/permissions/conftest.py
+++ b/sdk/python/tests/unit/permissions/conftest.py
@@ -1,0 +1,92 @@
+from unittest.mock import Mock
+
+import pytest
+
+from feast import FeatureView
+from feast.permissions.decorator import require_permissions
+from feast.permissions.permission import AuthzedAction, Permission
+from feast.permissions.policy import RoleBasedPolicy
+from feast.permissions.role_manager import RoleManager
+from feast.permissions.security_manager import (
+    SecurityManager,
+    set_security_manager,
+)
+
+
+class SecuredFeatureView(FeatureView):
+    def __init__(self, name, tags):
+        super().__init__(
+            name=name,
+            source=Mock(),
+            tags=tags,
+        )
+
+    @require_permissions(actions=[AuthzedAction.READ])
+    def read_protected(self) -> bool:
+        return True
+
+    @require_permissions(actions=[AuthzedAction.WRITE])
+    def write_protected(self) -> bool:
+        return True
+
+    def unprotected(self) -> bool:
+        return True
+
+
+@pytest.fixture
+def feature_views() -> list[FeatureView]:
+    return [
+        SecuredFeatureView("secured", {}),
+        SecuredFeatureView("special-secured", {}),
+    ]
+
+
+@pytest.fixture
+def role_manager() -> RoleManager:
+    rm = RoleManager()
+    rm.add_roles_for_user("r", ["reader"])
+    rm.add_roles_for_user("w", ["writer"])
+    rm.add_roles_for_user("rw", ["reader", "writer"])
+    return rm
+
+
+@pytest.fixture
+def security_manager() -> SecurityManager:
+    permissions = []
+    permissions.append(
+        Permission(
+            name="reader",
+            types=FeatureView,
+            with_subclasses=True,
+            policy=RoleBasedPolicy(roles=["reader"]),
+            actions=[AuthzedAction.READ],
+        )
+    )
+    permissions.append(
+        Permission(
+            name="writer",
+            types=FeatureView,
+            with_subclasses=True,
+            policy=RoleBasedPolicy(roles=["writer"]),
+            actions=[AuthzedAction.WRITE],
+        )
+    )
+    permissions.append(
+        Permission(
+            name="special",
+            types=FeatureView,
+            with_subclasses=True,
+            name_pattern="special.*",
+            policy=RoleBasedPolicy(roles=["admin", "special-reader"]),
+            actions=[AuthzedAction.READ, AuthzedAction.WRITE],
+        )
+    )
+
+    rm = RoleManager()
+    rm.add_roles_for_user("r", ["reader"])
+    rm.add_roles_for_user("w", ["writer"])
+    rm.add_roles_for_user("rw", ["reader", "writer"])
+    rm.add_roles_for_user("admin", ["reader", "writer", "admin"])
+    sm = SecurityManager(role_manager=rm, permissions=permissions)
+    set_security_manager(sm)
+    return sm

--- a/sdk/python/tests/unit/permissions/test_decorator.py
+++ b/sdk/python/tests/unit/permissions/test_decorator.py
@@ -1,73 +1,5 @@
-from unittest.mock import Mock
-
 import assertpy
 import pytest
-
-from feast import FeatureView
-from feast.permissions.decorator import require_permissions
-from feast.permissions.permission import AuthzedAction, Permission
-from feast.permissions.policy import RoleBasedPolicy
-from feast.permissions.role_manager import RoleManager
-from feast.permissions.security_manager import (
-    SecurityManager,
-    set_security_manager,
-)
-
-
-class SecuredFeatureView(FeatureView):
-    def __init__(self, name, tags):
-        super().__init__(
-            name=name,
-            source=Mock(),
-            tags=tags,
-        )
-
-    @require_permissions(actions=[AuthzedAction.READ])
-    def read_protected(self) -> bool:
-        return True
-
-    @require_permissions(actions=[AuthzedAction.WRITE])
-    def write_protected(self) -> bool:
-        return True
-
-    def unprotected(self) -> bool:
-        return True
-
-
-@pytest.fixture
-def security_manager() -> SecurityManager:
-    permissions = []
-    permissions.append(
-        Permission(
-            name="reader",
-            types=FeatureView,
-            with_subclasses=True,
-            policy=RoleBasedPolicy(roles=["reader"]),
-            actions=[AuthzedAction.READ],
-        )
-    )
-    permissions.append(
-        Permission(
-            name="writer",
-            types=FeatureView,
-            with_subclasses=True,
-            policy=RoleBasedPolicy(roles=["writer"]),
-            actions=[AuthzedAction.WRITE],
-        )
-    )
-
-    rm = RoleManager()
-    rm.add_roles_for_user("r", ["reader"])
-    rm.add_roles_for_user("w", ["writer"])
-    rm.add_roles_for_user("rw", ["reader", "writer"])
-    sm = SecurityManager(role_manager=rm, permissions=permissions)
-    set_security_manager(sm)
-    return sm
-
-
-@pytest.fixture
-def feature_view() -> FeatureView:
-    return SecuredFeatureView("secured", {})
 
 
 @pytest.mark.parametrize(
@@ -80,10 +12,10 @@ def feature_view() -> FeatureView:
     ],
 )
 def test_access_SecuredFeatureView(
-    security_manager, feature_view, user, can_read, can_write
+    security_manager, feature_views, user, can_read, can_write
 ):
     sm = security_manager
-    fv = feature_view
+    fv = feature_views[0]
 
     sm.set_current_user(user)
     if can_read:

--- a/sdk/python/tests/unit/permissions/test_permission.py
+++ b/sdk/python/tests/unit/permissions/test_permission.py
@@ -251,7 +251,7 @@ def test_resource_match_with_tags(required_tags, tags, result):
 
 
 @pytest.mark.parametrize(
-    ("permitted_actions, actions, result"),
+    ("permitted_actions, requested_actions, result"),
     [(AuthzedAction.ALL, a, True) for a in AuthzedAction.__members__.values()]
     + [
         (
@@ -269,6 +269,8 @@ def test_resource_match_with_tags(required_tags, tags, result):
         ),
     ],
 )
-def test_match_actions(permitted_actions, actions, result):
+def test_match_actions(permitted_actions, requested_actions, result):
     p = Permission(name="test", actions=permitted_actions)
-    assertpy.assert_that(p.match_actions(actions=actions)).is_equal_to(result)
+    assertpy.assert_that(
+        p.match_actions(requested_actions=requested_actions)
+    ).is_equal_to(result)

--- a/sdk/python/tests/unit/permissions/test_policy.py
+++ b/sdk/python/tests/unit/permissions/test_policy.py
@@ -2,7 +2,6 @@ import assertpy
 import pytest
 
 from feast.permissions.policy import AllowAll, RoleBasedPolicy
-from feast.permissions.role_manager import RoleManager
 
 
 @pytest.mark.parametrize(
@@ -18,15 +17,6 @@ def test_allow_all(user, dict):
         assertpy.assert_that(AllowAll.validate_user(user, **dict)).is_true()
     else:
         assertpy.assert_that(AllowAll.validate_user(user)).is_true()
-
-
-@pytest.fixture
-def role_manager() -> RoleManager:
-    rm = RoleManager()
-    rm.add_roles_for_user("r", ["reader"])
-    rm.add_roles_for_user("w", ["writer"])
-    rm.add_roles_for_user("rw", ["reader", "writer"])
-    return rm
 
 
 @pytest.mark.parametrize(

--- a/sdk/python/tests/unit/permissions/test_security_manager.py
+++ b/sdk/python/tests/unit/permissions/test_security_manager.py
@@ -43,7 +43,7 @@ def test_access_SecuredFeatureView_raise_error(
     for i, r in enumerate(resources):
         if allowed_single[i]:
             result = sm.assert_permissions(resources=r, actions=requested_actions)
-            assertpy.assert_that(result).is_equal_to([r])
+            assertpy.assert_that(result).is_equal_to(r)
         else:
             with pytest.raises(PermissionError):
                 sm.assert_permissions(resources=r, actions=requested_actions)
@@ -85,6 +85,6 @@ def test_access_SecuredFeatureView_filter_resources(
             resources=r, actions=requested_actions, filter_only=True
         )
         if allowed_single[i]:
-            assertpy.assert_that(result).is_equal_to([r])
+            assertpy.assert_that(result).is_equal_to(r)
         else:
-            assertpy.assert_that(result).is_equal_to([])
+            assertpy.assert_that(result).is_none()

--- a/sdk/python/tests/unit/permissions/test_security_manager.py
+++ b/sdk/python/tests/unit/permissions/test_security_manager.py
@@ -1,0 +1,90 @@
+import assertpy
+import pytest
+
+from feast.permissions.action import AuthzedAction
+from feast.permissions.decision import DecisionStrategy
+from feast.permissions.permission import Permission
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_module():
+    Permission.set_global_decision_strategy(DecisionStrategy.UNANIMOUS)
+
+
+@pytest.mark.parametrize(
+    "user, requested_actions, allowed, allowed_single",
+    [
+        (None, [], False, [False, False]),
+        ("r", [AuthzedAction.READ], False, [True, False]),
+        ("r", [AuthzedAction.WRITE], False, [False, False]),
+        ("w", [AuthzedAction.READ], False, [False, False]),
+        ("w", [AuthzedAction.WRITE], False, [True, False]),
+        ("rw", [AuthzedAction.READ], False, [True, False]),
+        ("rw", [AuthzedAction.WRITE], False, [True, False]),
+        ("rw", [AuthzedAction.READ, AuthzedAction.WRITE], False, [True, False]),
+        ("admin", [AuthzedAction.READ, AuthzedAction.WRITE], True, [True, True]),
+        ("admin", [AuthzedAction.QUERY, AuthzedAction.WRITE], True, [True, True]),
+    ],
+)
+def test_access_SecuredFeatureView_raise_error(
+    security_manager, feature_views, user, requested_actions, allowed, allowed_single
+):
+    sm = security_manager
+    resources = feature_views
+
+    sm.set_current_user(user)
+    if allowed:
+        result = sm.assert_permissions(resources=resources, actions=requested_actions)
+        assertpy.assert_that(result).is_equal_to(resources)
+    else:
+        with pytest.raises(PermissionError):
+            sm.assert_permissions(resources=resources, actions=requested_actions)
+
+    for i, r in enumerate(resources):
+        if allowed_single[i]:
+            result = sm.assert_permissions(resources=r, actions=requested_actions)
+            assertpy.assert_that(result).is_equal_to([r])
+        else:
+            with pytest.raises(PermissionError):
+                sm.assert_permissions(resources=r, actions=requested_actions)
+
+
+@pytest.mark.parametrize(
+    "user, requested_actions, allowed, allowed_single",
+    [
+        (None, [], False, [False, False]),
+        ("r", [AuthzedAction.READ], False, [True, False]),
+        ("r", [AuthzedAction.WRITE], False, [False, False]),
+        ("w", [AuthzedAction.READ], False, [False, False]),
+        ("w", [AuthzedAction.WRITE], False, [True, False]),
+        ("rw", [AuthzedAction.READ], False, [True, False]),
+        ("rw", [AuthzedAction.WRITE], False, [True, False]),
+        ("rw", [AuthzedAction.READ, AuthzedAction.WRITE], False, [True, False]),
+        ("admin", [AuthzedAction.READ, AuthzedAction.WRITE], True, [True, True]),
+        ("admin", [AuthzedAction.QUERY, AuthzedAction.WRITE], True, [True, True]),
+    ],
+)
+def test_access_SecuredFeatureView_filter_resources(
+    security_manager, feature_views, user, requested_actions, allowed, allowed_single
+):
+    sm = security_manager
+    resources = feature_views
+
+    sm.set_current_user(user)
+    result = sm.assert_permissions(
+        resources=resources, actions=requested_actions, filter_only=True
+    )
+    if allowed:
+        assertpy.assert_that(result).is_equal_to(resources)
+    else:
+        filtered = [r for i, r in enumerate(resources) if allowed_single[i]]
+        assertpy.assert_that(result).is_equal_to(filtered)
+
+    for i, r in enumerate(resources):
+        result = sm.assert_permissions(
+            resources=r, actions=requested_actions, filter_only=True
+        )
+        if allowed_single[i]:
+            assertpy.assert_that(result).is_equal_to([r])
+        else:
+            assertpy.assert_that(result).is_equal_to([])


### PR DESCRIPTION
- Added filter_only flag to assert_permissions and returning a list of filtered resources instead of PermissionError
- This can simplify the validation code that can use the returned value to move on the processing chain