### PR TITLE
Add feast CLI command to identify resources not covered by permissions

### DIFF
--- a/docs/reference/feast-cli-commands.md
+++ b/docs/reference/feast-cli-commands.md
@@ -165,22 +165,25 @@ List all registered permission
 feast permissions list
 
 Options:
-  --tags TEXT  Filter by tags (e.g. --tags 'key:value' --tags 'key:value,
-               key:value, ...'). Items return when ALL tags match.
-  --verbose
+  --tags TEXT    Filter by tags (e.g. --tags 'key:value' --tags 'key:value,
+                 key:value, ...'). Items return when ALL tags match.
+  -v, --verbose  Print the resources matching each configured permission
 ```
 
 ```text
 NAME                   TYPES            WITH_SUBCLASS    NAME_PATTERN           ACTIONS                             ROLES
-reader_permission1234  ['FeatureView']  True             transformed_conv_rate  [<AuthzedAction.READ: 'read'>]      {'reader'}
-writer_permission1234  ['FeatureView']  True             transformed_conv_rate  [<AuthzedAction.CREATE: 'create'>]  {'writer'}
+reader_permission1234  ['FeatureView']  True             transformed_conv_rate  ['READ]                             ['reader']
+writer_permission1234  ['FeatureView']  True             transformed_conv_rate  ['CREATE']                          ['writer']
+Note:The configured decision strategy is UNANIMOUS
 ```
+
+`verbose` option describes the resources matching each configured permission: 
 
 ```text
 feast permissions list -v
 ```
 
-```text            
+```text
 Permissions:
 
 permissions
@@ -210,6 +213,45 @@ policy:
     - reader
 
 ```
+
+### List of the configured roles
+List all the configured roles
+
+```text
+feast permissions list-roles
+
+Options:
+  --verbose Print the resources and actions permitted to each configured
+            role
+```
+
+```text
+ROLE NAME
+admin
+reader
+writer
+```
+
+`verbose` option describes the resources and actions permitted to each managed role: 
+
+```text
+feast permissions list-roles -v
+```
+
+```text            
+ROLE NAME          RESOURCE NAME               RESOURCE TYPE    PERMITTED ACTIONS
+admin              driver_hourly_stats_source  FileSource       ['CREATE', 'DELETE', 'QUERY_OFFLINE', 'QUERY_ONLINE', 'READ', 'UPDATE']
+admin              vals_to_add                 RequestSource    ['CREATE', 'DELETE', 'QUERY_OFFLINE', 'QUERY_ONLINE', 'READ', 'UPDATE']
+admin              driver_stats_push_source    PushSource       ['CREATE', 'DELETE', 'QUERY_OFFLINE', 'QUERY_ONLINE', 'READ', 'UPDATE']
+admin              driver_hourly_stats_source  FileSource       ['CREATE', 'DELETE', 'QUERY_OFFLINE', 'QUERY_ONLINE', 'READ', 'UPDATE']
+admin              vals_to_add                 RequestSource    ['CREATE', 'DELETE', 'QUERY_OFFLINE', 'QUERY_ONLINE', 'READ', 'UPDATE']
+admin              driver_stats_push_source    PushSource       ['CREATE', 'DELETE', 'QUERY_OFFLINE', 'QUERY_ONLINE', 'READ', 'UPDATE']
+reader             driver_hourly_stats         FeatureView      ['READ']
+reader             driver_hourly_stats_fresh   FeatureView      ['READ']
+...
+Note:The configured decision strategy is UNANIMOUS
+```
+
 
 ## Teardown
 

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -36,6 +36,7 @@ from feast.data_source import DataSource
 from feast.errors import FeastObjectNotFoundException, FeastProviderLoginError
 from feast.feature_view import FeatureView
 from feast.on_demand_feature_view import OnDemandFeatureView
+from feast.permissions.permission import Permission
 from feast.permissions.policy import RoleBasedPolicy
 from feast.repo_config import load_repo_config
 from feast.repo_operations import (
@@ -892,7 +893,7 @@ def feast_permissions_cmd():
 )
 @tagsOption
 @click.pass_context
-def feast_permissions_command(ctx: click.Context, verbose: bool, tags: list[str]):
+def feast_permissions_list_command(ctx: click.Context, verbose: bool, tags: list[str]):
     from tabulate import tabulate
 
     table: list[Any] = []
@@ -988,6 +989,9 @@ def feast_permissions_command(ctx: click.Context, verbose: bool, tags: list[str]
                 tablefmt="plain",
             )
         )
+        print(
+            f"{Style.BRIGHT}Note:{Style.RESET_ALL}The configured decision strategy is {Permission.get_global_decision_strategy().value.upper()}"
+        )
     else:
         cli_utils.print_permission_verbose_example()
 
@@ -1016,6 +1020,115 @@ def permission_describe(ctx: click.Context, name: str):
             yaml.safe_load(str(permission)), default_flow_style=False, sort_keys=False
         )
     )
+
+
+@feast_permissions_cmd.command(name="check")
+@click.pass_context
+def feast_permissions_check_command(ctx: click.Context):
+    """
+    Validate the permissions configuration
+    """
+    from tabulate import tabulate
+
+    all_unsecured_table: list[Any] = []
+    store = create_feature_store(ctx)
+    permissions = store.list_permissions()
+    objects = cli_utils.fetch_all_feast_objects(
+        store=store,
+    )
+
+    print(
+        f"{Style.BRIGHT + Fore.RED}The following resources are not secured by any permission configuration:{Style.RESET_ALL}"
+    )
+    for o in objects:
+        cli_utils.handle_permissions_check_command(
+            object=o, permissions=permissions, table=all_unsecured_table
+        )
+    print(
+        tabulate(
+            all_unsecured_table,
+            headers=[
+                "NAME",
+                "TYPE",
+            ],
+            tablefmt="plain",
+        )
+    )
+
+    all_unsecured_actions_table: list[Any] = []
+    print(
+        f"{Style.BRIGHT + Fore.RED}The following actions are not secured by any permission configuration (Note: this might not be a security concern, depending on the used APIs):{Style.RESET_ALL}"
+    )
+    for o in objects:
+        cli_utils.handle_permissions_check_command_with_actions(
+            object=o, permissions=permissions, table=all_unsecured_actions_table
+        )
+    print(
+        tabulate(
+            all_unsecured_actions_table,
+            headers=[
+                "NAME",
+                "TYPE",
+                "UNSECURED ACTIONS",
+            ],
+            tablefmt="plain",
+        )
+    )
+
+
+@feast_permissions_cmd.command(name="list-roles")
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Print the resources and actions permitted to each configured role",
+)
+@click.pass_context
+def feast_permissions_list_roles_command(ctx: click.Context, verbose: bool):
+    """
+    List all the configured roles
+    """
+    from tabulate import tabulate
+
+    table: list[Any] = []
+    store = create_feature_store(ctx)
+    permissions = store.list_permissions()
+    if not verbose:
+        cli_utils.handler_list_all_permissions_roles(
+            permissions=permissions, table=table
+        )
+        print(
+            tabulate(
+                table,
+                headers=[
+                    "ROLE NAME",
+                ],
+                tablefmt="plain",
+            )
+        )
+    else:
+        objects = cli_utils.fetch_all_feast_objects(
+            store=store,
+        )
+        cli_utils.handler_list_all_permissions_roles_verbose(
+            objects=objects, permissions=permissions, table=table
+        )
+        print(
+            tabulate(
+                table,
+                headers=[
+                    "ROLE NAME",
+                    "RESOURCE NAME",
+                    "RESOURCE TYPE",
+                    "PERMITTED ACTIONS",
+                ],
+                tablefmt="plain",
+            )
+        )
+
+        print(
+            f"{Style.BRIGHT}Note:{Style.RESET_ALL}The configured decision strategy is {Permission.get_global_decision_strategy().value.upper()}"
+        )
 
 
 if __name__ == "__main__":

--- a/sdk/python/feast/cli_utils.py
+++ b/sdk/python/feast/cli_utils.py
@@ -211,7 +211,6 @@ def fetch_all_feast_objects(store: FeatureStore) -> list[FeastObject]:
     objects.extend(store.list_batch_feature_views())
     objects.extend(store.list_feature_services())
     objects.extend(store.list_data_sources())
-    objects.extend(store.list_data_sources())
     objects.extend(store.list_validation_references())
     objects.extend(store.list_saved_datasets())
     objects.extend(store.list_permissions())

--- a/sdk/python/feast/cli_utils.py
+++ b/sdk/python/feast/cli_utils.py
@@ -279,6 +279,7 @@ def handler_list_all_permissions_roles_verbose(
         for o in objects:
             permitted_actions = ALL_ACTIONS.copy()
             for action in ALL_ACTIONS:
+                # Following code is derived from enforcer.enforce_policy but has a different return type and does not raise PermissionError
                 matching_permissions = [
                     p
                     for p in permissions

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -307,13 +307,17 @@ def start_server(
     keep_alive_timeout: int,
     registry_ttl_sec: int,
 ):
+    print("start_server called ")
     auth_type = str_to_auth_manager_type(store.config.auth_config.type)
+    print(f"auth_type is {auth_type}")
     init_security_manager(auth_type=auth_type, fs=store)
+    print("init_security_manager OK ")
     init_auth_manager(
         auth_type=auth_type,
         server_type=ServerType.REST,
         auth_config=store.config.auth_config,
     )
+    print("init_auth_manager OK ")
 
     if sys.platform != "win32":
         FeastServeApplication(


### PR DESCRIPTION
- Added `check` subcommand with `--verbose` option to list registered resources that are not covered by any permission
- Added `list-roles` subcommand with `--verbose` option to list registered permission roles and optional list of permitted actions per resource