### PR TITLE
Small fixes

### DIFF
--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -78,6 +78,7 @@ class OidcTokenParser(TokenParser):
                     "verify_signature": True,
                     "verify_exp": True,
                 },
+                leeway=10,  # accepts tokens generated up to 10 seconds in the past, in case of clock skew
             )
 
             if "preferred_username" not in data:

--- a/sdk/python/feast/permissions/enforcer.py
+++ b/sdk/python/feast/permissions/enforcer.py
@@ -44,7 +44,7 @@ def enforce_policy(
     _permitted_resources: list[FeastObject] = []
     for resource in resources:
         logger.debug(
-            f"Enforcing permission policies for {type(resource)}:{resource.name} to execute {actions}"
+            f"Enforcing permission policies for {type(resource).__name__}:{resource.name} to execute {actions}"
         )
         matching_permissions = [
             p
@@ -60,7 +60,7 @@ def enforce_policy(
                 )
                 evaluator.add_grant(
                     permission_grant,
-                    f"Permission {p.name} denied access: {permission_explanation}",
+                    f"Permission {p.name} denied execution of {[a.value.upper() for a in actions]} to {type(resource).__name__}:{resource.name}: {permission_explanation}",
                 )
 
                 if evaluator.is_decided():


### PR DESCRIPTION
1- added more details in the permission denial log
2- added `leeway` option to OIDC parser to allow the server to accept tokens created in the past (this happens when there are clock skews b/w the server and keycloak). Usually identified by a `The token is not yet valid` message