### PR TITLE
Incorporating the integration test code review comments from Tornike

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test-python-integration:
 test-python-integration-local:
 	FEAST_IS_LOCAL_TEST=True \
 	FEAST_LOCAL_ONLINE_CONTAINER=True \
-	python -m pytest -n 4 --color=yes --integration --durations=10 --timeout=1200 --timeout_method=thread --dist loadgroup \
+	python -m pytest -n 8 --color=yes --integration --durations=10 --timeout=1200 --timeout_method=thread --dist loadgroup \
 		-k "not test_lambda_materialization and not test_snowflake_materialization" \
 		sdk/python/tests
 

--- a/sdk/python/tests/integration/conftest.py
+++ b/sdk/python/tests/integration/conftest.py
@@ -1,11 +1,17 @@
+import logging
+
 import pytest
 from testcontainers.keycloak import KeycloakContainer
 
 from tests.utils.auth_permissions_util import setup_permissions_on_keycloak
 
+logger = logging.getLogger(__name__)
 
+
+@pytest.mark.xdist_group(name="keycloak")
 @pytest.fixture(scope="session")
 def start_keycloak_server():
+    logger.info("Starting keycloak instance")
     with KeycloakContainer("quay.io/keycloak/keycloak:24.0.1") as keycloak_container:
         setup_permissions_on_keycloak(keycloak_container.get_client())
         yield keycloak_container.get_url()

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -14,7 +14,6 @@ import yaml
 from minio import Minio
 from testcontainers.core.generic import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
-from testcontainers.keycloak import KeycloakContainer
 from testcontainers.minio import MinioContainer
 
 from feast import FileSource, RepoConfig
@@ -33,10 +32,7 @@ from feast.wait import wait_retry_backoff  # noqa: E402
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
 )
-from tests.utils.auth_permissions_util import (
-    include_auth_config,
-    setup_permissions_on_keycloak,
-)
+from tests.utils.auth_permissions_util import include_auth_config
 from tests.utils.http_server import check_port_open, free_port  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -437,7 +433,13 @@ class RemoteOfflineStoreDataSourceCreator(FileDataSourceCreator):
 class RemoteOfflineOidcAuthStoreDataSourceCreator(FileDataSourceCreator):
     def __init__(self, project_name: str, *args, **kwargs):
         super().__init__(project_name)
-        keycloak_url = self._setup_keycloak()
+        if "fixture_request" in kwargs:
+            request = kwargs["fixture_request"]
+            self.keycloak_url = request.getfixturevalue("start_keycloak_server")
+        else:
+            raise RuntimeError(
+                "fixture_request object is not passed to inject keycloak fixture dynamically."
+            )
         auth_config_template = """
 auth:
   type: oidc
@@ -449,15 +451,9 @@ auth:
   auth_server_url: {keycloak_url}
   auth_discovery_url: {keycloak_url}/realms/master/.well-known/openid-configuration
 """
-        self.auth_config = auth_config_template.format(keycloak_url=keycloak_url)
+        self.auth_config = auth_config_template.format(keycloak_url=self.keycloak_url)
         self.server_port: int = 0
         self.proc = None
-
-    def _setup_keycloak(self):
-        self.keycloak_container = KeycloakContainer("quay.io/keycloak/keycloak:24.0.1")
-        self.keycloak_container.start()
-        setup_permissions_on_keycloak(self.keycloak_container.get_client())
-        return self.keycloak_container.get_url()
 
     def setup(self, registry: RegistryConfig):
         parent_offline_config = super().create_offline_store_config()
@@ -509,11 +505,10 @@ auth:
         return self.remote_offline_store_config
 
     def get_keycloak_url(self):
-        return self.keycloak_container.get_url()
+        return self.keycloak_url
 
     def teardown(self):
         super().teardown()
-        self.keycloak_container.stop()
         if self.proc is not None:
             self.proc.kill()
 


### PR DESCRIPTION
- Incorporating the code review comments from Tornike to use @pytest.mark.xdist_group(name="keycloak").
- Reverting number of markers from 4 to 8 for the make file target test-python-integration-local.